### PR TITLE
rad-project: Add other git remote

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -11,6 +11,7 @@
 (import prelude/error-messages :as 'error)
 (import prelude/validation :as 'validation)
 (import prelude/cmd-parsing :unqualified)
+(import prelude/io :as 'io)
 (import prelude/io-utils
   '[set-git-config get-git-config process-git-with-exit!]
   :unqualified)
@@ -123,7 +124,11 @@
          ["(see radicle.xyz/docs/storage for more info)\n"]])))
     (match (prompt! question)
            "1" (init-git-ipfs-repo cid-of-empty-repo)
-           "2" (prompt! "Please input the remote git repo URL: ")
+           "2" (do
+                 (def remote-url (prompt! "Please input the remote git repo URL: "))
+                 (io/process-with-stdout-strict!
+                   "git" ["remote" "add" "origin" remote-url] "")
+                 remote-url)
            "3" (if (eq? current-remote "")
                  (do (put-str! "No current remote origin set; please select 1 or 2.")
                      (exit! !))

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -959,15 +959,28 @@ Like ``shell!``, but inherits stdin. WARNING: using ``shell!`` with
 unsanitized user input is a security hazard! Example:
 ``(shell-no-stdin! "ls -Glah")``.
 
+``(write-file! filename contents)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Write ``contents`` to file ``filename``.
+
 ``(process-with-stdout! command args to-write)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Like ``process!``, but captures stdout.
 
-``(write-file! filename contents)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``(process-with-stdout-stderr-exitcode! command args to-write)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Write ``contents`` to file ``filename``.
+Like ``process-with-stdout!``, but returns a vec
+``[stdout stderr exitcode]``. ``exitcode`` is either ``:ok`` or
+``[:error n]`` where ``n`` is a number.
+
+``(process-with-stdout-strict! command args to-write)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Like ``process-with-stdout!``, but prints an error message and exits if
+the command fails.
 
 ``(init-file-dict! file)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1007,13 +1020,6 @@ If
 is used.
 
 This requires the ``prelude/test/primitive-stub`` script to be loaded.
-
-``(process-with-stdout-stderr-exitcode! command args to-write)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Like ``process-with-stdout!``, but returns a vec
-``[stdout stderr exitcode]``. ``exitcode`` is either ``:ok`` or
-``[:error n]`` where ``n`` is a number.
 
 ``(prompt! prompt)``
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -859,6 +859,161 @@ True if ``str`` ends with ``substr``
 Appends the ``word`` with whitespace to get to length ``l``. If ``word``
 is longer than ``l``, the whole word is returned without padding.
 
+``prelude/error-messages``
+--------------------------
+
+Functions for user facing error messages. Functions should either have a
+descriptive name or additional comment so that the text can be edited
+without knowledge of where they are used. To verify changes, tests can
+be run with ``stack exec -- radicle test/all.rad``
+
+``(missing-arg arg cmd)``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Used for command line parsing when an argument to a command is missing.
+
+``(too-many-args cmd)``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Used for command line parsing when there are too many arguments passed
+to a command.
+
+``(missing-arg-for-opt opt valid-args)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Used for command line parsing when an option requires an argument.
+
+``(invalid-arg-for-opt arg opt valid-args)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Used for command line parsing when the argument for an option is
+invalid.
+
+``(invalid-opt-for-cmd opt cmd)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Used for command line parsing when the option for a given command is
+unkown
+
+``(dir-already-exists dir-name)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad project checkout`` is aborted, if there is already a directory
+with the name of the project ``dir-name`` in the current directory.
+
+``(git-clone-failure origin name)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad project checkout`` is aborted, if cloning the repo ``name`` form
+``origin`` failed.
+
+``(upstream-commit-failure)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad project init`` is aborted when creating an empty commit failed in
+preparation to setting the upstream master branch.
+
+``(upstream-push-failure)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad project init`` is aborted when pushing the empty commit failed
+while setting the upstream master branch.
+
+``(item-not-found item item-number)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any command on a specific patch/issue aborts if it does not exist.
+
+``(whole-item-number item)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any command on a specific patch/issue aborts if the provided
+``item-number`` is not a whole number.
+
+``(missing-item-number item action)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any command on a specific patch/issue aborts if the ``item-number`` is
+not provided.
+
+``(state-change-failure item state)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On changing the state of a patch/issue if the daemon returned an error.
+
+``(no-number-returned item)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On creating a patch/issue, when the creation was successful, but no
+patch/issue number was returned.
+
+``(unknown-command cmd)``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An unknown command for an app. E.g. ``rad issue foobar``
+
+``(unknown-commit commit)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad patch propose`` aborts if the provided commit is unknown.
+
+``(parent-commit-not-master commit)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad patch propose`` aborts if the provided commit is unknown.
+
+``(checkout-new-branch-failure branch)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad patch checkout`` aborts if creating and switching to the patch
+branch fails.
+
+``(checkout-master-failure)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad patch accept`` aborts if checking out the master branch fails.
+
+``(applying-patch-failure)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad patch checkout`` aborts if applying the patch to the patch branch
+fails. Conflicts have to be resolved manually.
+
+``(applying-accepted-patch-failure)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad patch accept`` aborts if applying the patch to master fails.
+Conflicts have to be resolved manually as well as pushing the commit.
+
+``(push-patch-failure)``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rad patch accept`` aborts if pushing the patch failed.
+
+``(missing-key-file)``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Any request to the machine is aborted, when the key file can't be found.
+
+``(rad-ipfs-name-publish-failure stderr)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Printed when the ``rad ipfs name publish`` command in
+``init-git-ipfs-repo`` in ``rad-project`` fails. Takes stderr of the
+command as an argument.
+
+``(rad-ipfs-key-gen-failure stderr)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Printed when the ``rad ipfs key gen`` command in ``init-git-ipfs-repo``
+in ``rad-project`` fails. Takes stderr of the command as an argument.
+
+``(process-exit-error command args exit-code stderr)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Printed when the a sub process exits with a non-zero exit code. Includes
+the stderr output in the message.
+
 ``prelude/dict``
 ----------------
 

--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -11,6 +11,7 @@
 (file-module! "prelude/seq.rad")
 (file-module! "prelude/list.rad")
 (file-module! "prelude/strings.rad")
+(file-module! "prelude/error-messages.rad")
 (file-module! "prelude/dict.rad")
 (file-module! "prelude/io.rad")
 (file-module! "prelude/maybe.rad")

--- a/rad/prelude/error-messages.rad
+++ b/rad/prelude/error-messages.rad
@@ -11,6 +11,7 @@
    parent-commit-not-master checkout-new-branch-failure checkout-master-failure
    applying-patch-failure applying-accepted-patch-failure push-patch-failure
    missing-key-file rad-ipfs-name-publish-failure rad-ipfs-key-gen-failure
+   process-exit-error
    ]}
 
 (import prelude/strings :unqualified)
@@ -18,6 +19,7 @@
 ;; parsing
 
 (def missing-arg
+  "Used for command line parsing when an argument to a command is missing."
   (fn [arg cmd]
     (string-append "Missing argument \"" arg "\" for command \"" cmd "\"")))
 
@@ -25,6 +27,7 @@
   [(missing-arg "foo" "bar") ==> "Missing argument \"foo\" for command \"bar\""])
 
 (def too-many-args
+  "Used for command line parsing when there are too many arguments passed to a command."
   (fn [cmd]
     (string-append "Too many arguments for command \"" cmd "\"")))
 
@@ -39,6 +42,7 @@
   [(valid-args-help ["foo" "bar"]) ==> "Valid arguments: foo, bar"])
 
 (def missing-arg-for-opt
+  "Used for command line parsing when an option requires an argument."
   (fn [opt valid-args]
     (string-append
       "Missing argument for option \"" opt "\". "
@@ -48,6 +52,7 @@
   [(missing-arg-for-opt "-s" ["foo" "bar"]) ==> "Missing argument for option \"-s\". Valid arguments: foo, bar"])
 
 (def invalid-arg-for-opt
+  "Used for command line parsing when the argument for an option is invalid."
   (fn [arg opt valid-args]
     (string-append
       "Invalid argument \"" arg "\" for option \"" opt "\". "
@@ -57,6 +62,7 @@
   [(invalid-arg-for-opt "foobar" "-s" ["foo" "bar"]) ==> "Invalid argument \"foobar\" for option \"-s\". Valid arguments: foo, bar"])
 
 (def invalid-opt-for-cmd
+  "Used for command line parsing when the option for a given command is unkown"
   (fn [opt cmd]
     (string-append "Invalid option \"" opt "\" for command " cmd ".")))
 
@@ -309,3 +315,21 @@ Do `rad key create` to create your own key pair and rerun your command."])
 
 (:test "rad-ipfs-name-publish-failure"
   [(rad-ipfs-name-publish-failure "stderr") ==>  "error: Failed to publish key for Git IPFS repository:\nstderr"])
+
+;; sub-processes
+
+(def process-exit-error
+  "Printed when the a sub process exits with a non-zero exit code.
+  Includes the stderr output in the message."
+  (fn [command args exit-code stderr]
+    (def command-line (intercalate " " (cons command args)))
+    (def message (string-append "error: Command \"" command-line "\" exited with status code " (show exit-code)))
+    (def stderr-output (map (fn [l] (string-append "  stderr: " l)) stderr))
+    (unlines (cons message stderr-output))
+    ))
+
+(:test "process-exit-error"
+  [(process-exit-error "foo" ["arg1" "arg2"] 5 ["fail1" "fail2"]) ==>
+"error: Command \"foo arg1 arg2\" exited with status code 5
+  stderr: fail1
+  stderr: fail2"])

--- a/rad/prelude/io.rad
+++ b/rad/prelude/io.rad
@@ -1,12 +1,15 @@
 {:module 'prelude/io
  :doc "Some basic I/O functions."
  :exports '[print! shell! process! read-line! read-file-value! read-file-values!
-            shell-with-stdout! shell-no-stdin! process-with-stdout! write-file!
+            shell-with-stdout! shell-no-stdin! write-file!
+            process-with-stdout! process-with-stdout-stderr-exitcode!
+            process-with-stdout-strict!
             init-file-dict! read-file-key! write-file-key! ls! modify-file!
-            install-fake-filesystem! process-with-stdout-stderr-exitcode! prompt!
+            install-fake-filesystem! prompt!
            ]}
 
 (import prelude/patterns :unqualified)
+(import prelude/strings :as 'strings)
 (import prelude/dict :unqualified)
 
 (def read-line!
@@ -187,6 +190,23 @@ process exited normally and `[:error n]` otherwise. Example: `(process!
 (:test "process-with-stdout-stderr-exitcode!"
   [ (process-with-stdout-stderr-exitcode! "echo" ["hi"] "") ==> [["hi"] [] :ok] ]
   [ (process-with-stdout-stderr-exitcode! "false" [] "") ==> [[] [] [:error 1]] ]
+)
+
+(def process-with-stdout-strict!
+  "Like `process-with-stdout!`, but prints an error message and exits if the command fails."
+  (fn [command args to-write]
+    (match (process-with-stdout-stderr-exitcode! command args to-write)
+      ['stdout _ :ok] stdout
+      ['stdout 'stderr [:error 'n]]
+        (do
+          (def command-line (strings/intercalate " " (cons command args)))
+          (put-str! (string-append "error: Command \"" command-line "\" exited with status code " (show n)))
+          (map (fn [l] (put-str! (string-append "  stderr: " l))) stderr)
+          (exit! 1))
+      )))
+
+(:test "process-with-stdout-strict!"
+  [ (process-with-stdout-strict! "echo" ["hi"] "") ==> ["hi"] ]
 )
 
 ;; General utilities

--- a/rad/prelude/io.rad
+++ b/rad/prelude/io.rad
@@ -11,6 +11,7 @@
 (import prelude/patterns :unqualified)
 (import prelude/strings :as 'strings)
 (import prelude/dict :unqualified)
+(import prelude/error-messages :as 'error)
 
 (def read-line!
   "Read a single line of input and interpret it as radicle data."
@@ -197,11 +198,9 @@ process exited normally and `[:error n]` otherwise. Example: `(process!
   (fn [command args to-write]
     (match (process-with-stdout-stderr-exitcode! command args to-write)
       ['stdout _ :ok] stdout
-      ['stdout 'stderr [:error 'n]]
+      ['stdout 'stderr [:error 'exit-code]]
         (do
-          (def command-line (strings/intercalate " " (cons command args)))
-          (put-str! (string-append "error: Command \"" command-line "\" exited with status code " (show n)))
-          (map (fn [l] (put-str! (string-append "  stderr: " l))) stderr)
+          (put-str! (error/process-exit-error command args exit-code stderr))
           (exit! 1))
       )))
 

--- a/reference-doc.yaml
+++ b/reference-doc.yaml
@@ -138,6 +138,7 @@ modules:
 - prelude/seq
 - prelude/list
 - prelude/strings
+- prelude/error-messages
 - prelude/dict
 - prelude/io
 - prelude/exception

--- a/test/e2e/ProjectAppTest.hs
+++ b/test/e2e/ProjectAppTest.hs
@@ -1,6 +1,7 @@
 module ProjectAppTest
     ( test_project_show_id
     , test_project_checkout
+    , test_project_init_own_remote
     ) where
 
 import           Protolude
@@ -30,3 +31,17 @@ test_project_checkout = testCase "project checkout" $ do
     withCurrentDirectory "project-name" $ do
         showIdOut <- runTestCommand' "rad-project" ["show-id"] []
         assertContains showIdOut projectId
+
+test_project_init_own_remote :: TestTree
+test_project_init_own_remote = testCase "project init own remote" $ do
+    prepareRadicle
+    _ <- runTestCommand' "rad-project" ["init"]
+        [ "project-name"
+        , "project desc"
+        , "2"
+        -- @.@ is a working remote URL that does not require an actual
+        -- remote. We need a working remote becuase @project init@ does
+        -- a @git fetch@.
+        , "."]
+    remoteUrl <- runTestCommand "git" ["remote", "get-url" ,"origin"]
+    assertEqual "Remote URL does not match" "." remoteUrl


### PR DESCRIPTION
If the user wants to add their own remote on `project init` we actually add the input URL as a git remote. We also provide tests for this.