### PR TITLE
rad-project: Wrong import fails 'rad project checkout'

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -17,7 +17,7 @@
 
 (import monadic/issue '[create-issue-machine!] :unqualified)
 (import monadic/project
-  '[get-project-url! get-meta create-project! add-rsm! first-rsm-of-type!]
+  '[get-project-url! get-meta! create-project! add-rsm! first-rsm-of-type!]
   :unqualified)
 
 (def help

--- a/package.yaml
+++ b/package.yaml
@@ -125,6 +125,7 @@ tests:
     - tasty-hunit
     - temporary
     - text
+    - unliftio
 
 executables:
   rad:

--- a/test/e2e/PatchAppTest.hs
+++ b/test/e2e/PatchAppTest.hs
@@ -9,10 +9,8 @@ import           Test.E2ESupport
 
 test_patch_propose :: TestTree
 test_patch_propose = testCaseSteps "patch propose" $ \step -> do
+    prepareRadicle
     step "Init project"
-    _ <- runTestCommand "rad-key" ["create"]
-    _ <- runTestCommand "git" ["config", "--global", "user.name", "Alice"]
-    _ <- runTestCommand "git" ["config", "--global", "user.email", "alice@example.com"]
     _ <- runTestCommand' "rad-project" ["init"] ["project-name", "project desc", "1"]
     _ <- runTestCommand "git" ["checkout", "-b", "f/test"]
     _ <- runTestCommand "touch" ["test"]

--- a/test/e2e/ProjectAppTest.hs
+++ b/test/e2e/ProjectAppTest.hs
@@ -1,17 +1,32 @@
 module ProjectAppTest
     ( test_project_show_id
+    , test_project_checkout
     ) where
 
 import           Protolude
 
 import           Test.E2ESupport
+import           UnliftIO.Directory
 
 test_project_show_id :: TestTree
 test_project_show_id = testCase "project show-id" $ do
-    _ <- runTestCommand "rad-key" ["create"]
-    _ <- runTestCommand "git" ["config", "--global", "user.name", "Alice"]
-    _ <- runTestCommand "git" ["config", "--global", "user.email", "alice@example.com"]
+    prepareRadicle
+
     _ <- runTestCommand' "rad-project" ["init"] ["project-name", "project desc", "1"]
     projectId <- runTestCommand "git" ["config", "--get" ,"radicle.project-id"]
     showIdOut <- runTestCommand' "rad-project" ["show-id"] []
     assertContains showIdOut projectId
+
+test_project_checkout :: TestTree
+test_project_checkout = testCase "project checkout" $ do
+    prepareRadicle
+
+    createDirectory "origin"
+    projectId <- withCurrentDirectory "origin" $ do
+        _ <- runTestCommand' "rad-project" ["init"] ["project-name", "project desc", "1"]
+        runTestCommand "git" ["config", "--get" ,"radicle.project-id"]
+
+    runTestCommand "rad-project" ["checkout", projectId]
+    withCurrentDirectory "project-name" $ do
+        showIdOut <- runTestCommand' "rad-project" ["show-id"] []
+        assertContains showIdOut projectId

--- a/test/e2e/Test/E2ESupport.hs
+++ b/test/e2e/Test/E2ESupport.hs
@@ -10,6 +10,8 @@ module Test.E2ESupport
     , testCaseSteps
     , testCase
 
+    , prepareRadicle
+
     , runTestCommand
     , runTestCommand'
 
@@ -96,6 +98,15 @@ assertContains str substr =
     if substr `T.isInfixOf` str
     then pure ()
     else assertFailure $ "\"" <> substr <> "\" is not contained in \"" <> str <> "\""
+
+-- * Setup
+
+-- | Runs @rad key create@ and sets the Git user name and email.
+prepareRadicle :: TestM Text
+prepareRadicle = do
+    _ <- runTestCommand "rad-key" ["create"]
+    _ <- runTestCommand "git" ["config", "--global", "user.name", "Alice"]
+    runTestCommand "git" ["config", "--global", "user.email", "alice@example.com"]
 
 -- * Run commands
 


### PR DESCRIPTION
Fix a typo in an import that made `rad project checkout` fail. Also provide tests for `rad project checkout`.