### PR TITLE
Create aliases for Debian and macOS packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,4 +103,14 @@ jobs:
 
             version="$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
             VERSION=$version TARGET=darwin ./packaging/build-package.sh
+            if [ "$CIRCLE_BRANCH" == "master" ]; then
+              # Upload package aliases for easier distribution
+              cp  \
+                "packaging/out/radicle_${version}_x86_64-darwin.tar.gz" \
+                "packaging/out/radicle_${date}_x86_64-darwin.tar.gz"
+
+              cp  \
+                "packaging/out/radicle_${version}_x86_64-darwin.tar.gz" \
+                "packaging/out/radicle_latest_x86_64-darwin.tar.gz"
+            fi
             ./packaging/upload.sh

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ rad daemon-radicle
 
 We provide `.deb` packages for Debian-based systems.
 
-    wget https://storage.googleapis.com/static.radicle.xyz/releases/radicle_2019.03.01_amd64.deb
-    apt install ./radicle_2019.03.01_amd64.deb
+    wget https://storage.googleapis.com/static.radicle.xyz/releases/radicle_latest_amd64.deb
+    sudo apt install ./radicle_latest_amd64.deb
 
 To use Radicle you need to start the Radicle daemon
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -229,9 +229,14 @@ steps:
       VERSION=$version TARGET=debian ./packaging/build-package.sh
 
       if [ "$BRANCH_NAME" == "master" ]; then
+        # Upload package aliases for easier distribution
         cp  \
           "packaging/out/radicle_${version}_amd64.deb" \
           "packaging/out/radicle_${date}_amd64.deb"
+
+        cp  \
+          "packaging/out/radicle_${version}_amd64.deb" \
+          "packaging/out/radicle_latest_amd64.deb"
       fi
 
       ./packaging/upload.sh


### PR DESCRIPTION
Master builds for Debian and macOS packages are now available as `radicle_latest_$arch` from Google storage. We can update the installation instructions and people will always get the latest version.