### PR TITLE
Generalize action monad for IPFS code

### DIFF
--- a/exe/Daemon.hs
+++ b/exe/Daemon.hs
@@ -7,7 +7,16 @@
 -- the RFC>.
 module Daemon (main) where
 
-import           Protolude hiding (catch, fromStrict, option, poll, tryJust)
+import           Protolude hiding
+                 ( async
+                 , catch
+                 , fromStrict
+                 , option
+                 , poll
+                 , tryJust
+                 , wait
+                 , waitEitherCatchCancel
+                 )
 
 import           Control.Exception.Safe hiding (Handler)
 import qualified Data.Map.Strict as Map
@@ -17,7 +26,7 @@ import           Network.Wai.Handler.Warp (run)
 import           Options.Applicative
 import           Servant
 import           System.IO (BufferMode(..), hSetBuffering)
-import           UnliftIO.Async (pooledForConcurrentlyN_)
+import           UnliftIO.Async
 
 import           Radicle.Daemon.Error
 import qualified Radicle.Daemon.HttpApi as Api
@@ -190,7 +199,7 @@ init follows = pooledForConcurrentlyN_ 5 (Map.toList follows) initMachine
 -- /writer/.
 newMachine :: Daemon Api.NewResponse
 newMachine = do
-    id <- wrapException CouldNotCreateMachine (liftIO createMachine)
+    id <- wrapException CouldNotCreateMachine createMachine
     sub <- initDaemonSubscription id
     logInfo "Created new IPFS machine" [("machine-id", getMachineId id)]
     m <- emptyMachine id Writer sub
@@ -339,9 +348,8 @@ addInputs is idx m = do
   (newState, _) <- runInputs m is
   updateState newState idx m
 
--- | Run some IPFS IO related to a specific machine.
-machineIpfs :: MachineId -> IO a -> Daemon a
-machineIpfs id io = wrapException (MachineError id . IpfsError) (liftIO io)
+machineIpfs :: MachineId -> Daemon a -> Daemon a
+machineIpfs id io = wrapException (MachineError id . IpfsError) io
 
 -- | Do some high-freq polling for a while.
 bumpPolling :: MachineId -> Daemon ()
@@ -452,8 +460,8 @@ writeInputs source id inputs nonce = do
 -- * Polling
 
 -- | Fetch and apply new inputs for all machines in reader mode.
-poll :: Daemon ()
-poll = traverseMachines pollMachine
+pollMachines :: Daemon ()
+pollMachines = traverseMachines pollMachine
   where
     pollMachine :: MachineId -> CachedMachine -> Daemon ()
     pollMachine _ = \case
@@ -494,7 +502,7 @@ timeSince x = timeDelta x <$> Time.getSystemTime
 initPolling :: Env -> IO Void
 initPolling env = do
   threadDelay (millisToMicros highFreqPollPeriod)
-  res <- runDaemon env poll
+  res <- runDaemon env pollMachines
   -- If polling encounters an error it should log it but continue.
   -- Later we might detect some errors as critical and halt the
   -- daemon.

--- a/exe/Daemon.hs
+++ b/exe/Daemon.hs
@@ -109,7 +109,7 @@ waitForIpfsDaemon = do
             go (n - 1)
 
     checkIpfsIsOnline :: Daemon Bool
-    checkIpfsIsOnline = liftIO $ do
+    checkIpfsIsOnline = do
         result <- tryJust isIpfsExceptionNoDaemon Ipfs.version
         pure $ case result of
             Left _  -> False

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ library:
   - text
   - time
   - unliftio-core
+  - unliftio
   - unordered-containers
   - uuid
   - wreq

--- a/src/Radicle/Daemon/Ipfs.hs
+++ b/src/Radicle/Daemon/Ipfs.hs
@@ -1,5 +1,6 @@
 module Radicle.Daemon.Ipfs
   ( MachineId(..)
+  , MonadMachineIpfs
   , Message(..)
   , InputsApplied(..)
   , SubmitInputs(..)
@@ -18,10 +19,11 @@ module Radicle.Daemon.Ipfs
   , jsonToValue
   ) where
 
-import           Protolude hiding (bracket, catches)
+import           Protolude hiding (async, bracket, catches)
 
 import           Control.Exception.Safe
 import           Control.Monad.Fail
+import           Control.Monad.IO.Unlift
 import           Data.Aeson (decodeStrict, (.:), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
@@ -29,6 +31,7 @@ import           Data.IPLD.CID
 import qualified Data.Map.Strict as Map
 import qualified Data.Unique as Unique
 import           System.Timeout
+import           UnliftIO.Async
 
 import           Radicle.Internal.Core
 import           Radicle.Internal.Parse
@@ -46,6 +49,9 @@ valueToJson :: Value -> Aeson.Value
 valueToJson = Aeson.String . renderCompactPretty
 
 -- * Types
+
+
+class (MonadIO m, MonadThrow m, MonadUnliftIO m) => MonadMachineIpfs m
 
 newtype MachineId = MachineId { getMachineId :: Text }
     deriving (Show, Eq, Ord, Generic)
@@ -155,8 +161,8 @@ instance Aeson.FromJSON MachineEntryIndex where
 -- | Write and pin some inputs to an IPFS machine.
 -- TODO: we might want to make this safer by taking the expected head
 -- MachineEntryIndex as an argument.
-writeIpfs :: MachineId -> [Value] -> IO MachineEntryIndex
-writeIpfs (MachineId ipnsId) values = do
+writeIpfs :: (MonadMachineIpfs m) => MachineId -> [Value] -> m MachineEntryIndex
+writeIpfs (MachineId ipnsId) values = liftIO $ do
     Ipfs.NameResolveResponse cid <- Ipfs.nameResolve ipnsId
     Ipfs.DagPutResponse newEntryCid <- Ipfs.dagPut $ MachineEntry values cid
     Ipfs.namePublish ipnsId $ Ipfs.AddressIpfs newEntryCid
@@ -169,12 +175,12 @@ machineTopic :: MachineId -> Topic
 machineTopic (MachineId id) = Topic ("radicle:machine:" <> id)
 
 -- | Publish a 'Message' on a machine's IPFS pubsub topic.
-publish :: MachineId -> Message -> IO ()
-publish id msg = Ipfs.publish (getTopic (machineTopic id)) (Aeson.encode msg)
+publish :: (MonadMachineIpfs m) => MachineId -> Message -> m ()
+publish id msg = liftIO $ Ipfs.publish (getTopic (machineTopic id)) (Aeson.encode msg)
 
 -- | Subscribe to messages on a machine's IPFS pubsub topic.
-subscribeForever :: MachineId -> (Either Text Message -> IO ()) -> IO ()
-subscribeForever id messageHandler = Ipfs.subscribe topic pubsubHandler
+subscribeForever :: (MonadMachineIpfs m) => MachineId -> (Either Text Message -> IO ()) -> m ()
+subscribeForever id messageHandler = liftIO $ Ipfs.subscribe topic pubsubHandler
   where
     Topic topic = machineTopic id
     pubsubHandler Ipfs.PubsubMessage{..} = messageHandler $ case decodeStrict messageData of
@@ -188,21 +194,23 @@ subscribeForever id messageHandler = Ipfs.subscribe topic pubsubHandler
 --
 -- If @maybeFrom@ is @Just index@ all inputs after (but not
 -- including) @index@ are returned. Otherwise all inputs are returned.
-machineInputsFrom :: MachineId -> Maybe MachineEntryIndex -> IO (MachineEntryIndex, [Value])
+machineInputsFrom
+    :: forall m. (MonadMachineIpfs m)
+    => MachineId -> Maybe MachineEntryIndex -> m (MachineEntryIndex, [Value])
 machineInputsFrom (MachineId ipnsId) maybeFrom = do
     let MachineEntryIndex fromCid = fromMaybe (MachineEntryIndex emptyMachineCid) maybeFrom
-    Ipfs.NameResolveResponse cid <- Ipfs.nameResolve ipnsId
+    Ipfs.NameResolveResponse cid <- liftIO $ Ipfs.nameResolve ipnsId
     blocks <- getBlocks cid fromCid
     pure $ (MachineEntryIndex cid, blocks)
   where
-    getBlocks :: CID -> CID -> IO [Value]
+    getBlocks :: CID -> CID -> m [Value]
     getBlocks cid fromCid = do
         if cid == fromCid || cid == emptyMachineCid
         then pure []
         else do
             let addr = Ipfs.AddressIpfs cid
-            entry <- Ipfs.dagGet addr
-            _ <- Ipfs.pinAdd addr
+            entry <- liftIO $ Ipfs.dagGet addr
+            _ <- liftIO $ Ipfs.pinAdd addr
             rest <- getBlocks (entryPrevious entry) fromCid
             pure $ rest <> entryExpressions entry
 
@@ -222,8 +230,8 @@ emptyMachineCid =
 --
 -- Generates a new IPNS key and sets the IPNS record to the empty
 -- machine DAG node.
-createMachine :: IO MachineId
-createMachine = do
+createMachine :: (MonadMachineIpfs m) => m MachineId
+createMachine = liftIO $ do
     uuid <- UUID.uuid
     Ipfs.KeyGenResponse ipnsId <- Ipfs.keyGen uuid
     Ipfs.namePublish ipnsId $ Ipfs.AddressIpfs emptyMachineCid
@@ -231,8 +239,8 @@ createMachine = do
 
 -- | Publish to IPNS a machine entry index for a machine. Should only be issued
 -- by the writer.
-ipnsPublish :: MachineId -> MachineEntryIndex -> IO ()
-ipnsPublish id (MachineEntryIndex cid) = Ipfs.namePublish (getMachineId id) $ Ipfs.AddressIpfs cid
+ipnsPublish :: (MonadMachineIpfs m) => MachineId -> MachineEntryIndex -> m ()
+ipnsPublish id (MachineEntryIndex cid) = liftIO $ Ipfs.namePublish (getMachineId id) $ Ipfs.AddressIpfs cid
 
 -- * Topic subscriptions
 
@@ -250,9 +258,9 @@ newtype TopicSubscription = TopicSubscription
 --
 -- @logParseError@ is called with the raw message content if a message
 -- cannot be parsed.
-initSubscription :: MachineId -> (Text -> IO ()) -> IO TopicSubscription
+initSubscription :: (MonadMachineIpfs m) => MachineId -> (Text -> IO ()) -> m TopicSubscription
 initSubscription id logParseError = do
-    hdlrs <- newMVar Map.empty
+    hdlrs <- liftIO $ newMVar Map.empty
     _ <- async $ subscribeForever id (mainHdlr hdlrs)
     pure $ TopicSubscription hdlrs
   where

--- a/src/Radicle/Daemon/Monad.hs
+++ b/src/Radicle/Daemon/Monad.hs
@@ -21,6 +21,7 @@ import           Control.Exception.Safe
 import           Control.Monad.IO.Unlift
 
 import           Radicle.Daemon.Error
+import           Radicle.Daemon.Ipfs (MonadMachineIpfs)
 import           Radicle.Daemon.Logging
 import           Radicle.Daemon.MachineStore
 
@@ -39,6 +40,8 @@ instance MonadLog Daemon where
 
 instance MonadMachineStore Daemon where
     askMachines = asks machines
+
+instance MonadMachineIpfs Daemon
 
 -- * Environment
 

--- a/src/Radicle/Daemon/Monad.hs
+++ b/src/Radicle/Daemon/Monad.hs
@@ -24,6 +24,7 @@ import           Radicle.Daemon.Error
 import           Radicle.Daemon.Ipfs (MonadMachineIpfs)
 import           Radicle.Daemon.Logging
 import           Radicle.Daemon.MachineStore
+import qualified Radicle.Ipfs as Ipfs
 
 
 newtype Daemon a = Daemon (ReaderT Env IO a)
@@ -40,6 +41,8 @@ instance MonadLog Daemon where
 
 instance MonadMachineStore Daemon where
     askMachines = asks machines
+
+instance Ipfs.MonadIpfs Daemon
 
 instance MonadMachineIpfs Daemon
 


### PR DESCRIPTION
This PR consists of two commits that generalize the monad that actions from `Radicle.Ipfs` and `Radicle.Daemon.Ipfs` are run in from `IO` to `MonadX m`. At the moment the `MonadX` classes do not have any methods but once we replace `wreq` with `http-client` we will make the classes isomorphic to `Reader Client` where `Client` carries the HTTP client information.