### PR TITLE
Don’t load failed machines over and over

### DIFF
--- a/exe/Daemon.hs
+++ b/exe/Daemon.hs
@@ -472,10 +472,8 @@ poll = traverseMachines pollMachine
           logDebug "Polling.." [("machine-id", getMachineId machineId)]
           refreshAsReader machineId >> pure ()
         modifyMachine machineId $ \m' -> pure (m' { machinePolling = newPoll }, ())
-      UninitialisedReader t -> do
-        delta <- liftIO $ timeSince t
-        when (delta > lowFreqPollPeriod) $ initReaderNoFail id $> ()
-      _ -> pure () -- Writers don't require any polling.
+      -- Don't update owned and unavailable machines.
+      _ -> pure ()
 
 -- | Returns the amount of time since the last time the machine was
 -- updated.

--- a/exe/Daemon.hs
+++ b/exe/Daemon.hs
@@ -456,7 +456,7 @@ poll :: Daemon ()
 poll = traverseMachines pollMachine
   where
     pollMachine :: MachineId -> CachedMachine -> Daemon ()
-    pollMachine id = \case
+    pollMachine _ = \case
       Cached m@Machine{ machineMode = Reader, .. } -> do
         delta <- liftIO $ sinceLastUpdate m
         let (shouldPoll, newPoll) =


### PR DESCRIPTION
Before we tried to reload machines that failed to initialize every ten seconds. This included invalid machines that failed to evaluate properly. We disable this behavior until we have a better strategy to catch errors and have exponential back-off.