### PR TITLE
Concurrently initialize machines

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -155,15 +155,16 @@ executables:
     source-dirs: exe
     other-modules: []
     dependencies:
-    - radicle
-    - mtl
     - containers
+    - mtl
     - optparse-applicative
+    - radicle
     - safe-exceptions
     - servant-server
     - text
-    - warp
     - time
+    - unliftio
+    - warp
     ghc-options: -main-is Daemon
 
   radicle-doc:


### PR DESCRIPTION
Initialization of machines is bounded by IPNS resolution over network. To make it fast we run the initialization concurrently.