### PR TITLE
rad-project: Remove dead link to docs

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -121,7 +121,7 @@
                "" []
                'url ["3. Remote origin of existing current git repository:"
                      (string-append "   " url)])
-         ["(see www.radicle.xyz/docs/storage for more info)\n"]])))
+         ])))
     (match (prompt! question)
            "1" (init-git-ipfs-repo cid-of-empty-repo)
            "2" (do


### PR DESCRIPTION
We currently don’t have anything in the docs explaining this.

Fixes #550