### PR TITLE
Skip uploading packages on forked PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,13 +96,19 @@ jobs:
       - run:
           name: Package
           command: |
+            version="$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
+            VERSION=$version TARGET=darwin ./packaging/build-package.sh
+
+            # This is only set when building forked PRs
+            if [ -n "$CIRCLE_PR_REPONAME" ]; then
+              echo "Skipping uploads for forks"
+              exit 0
+            fi
+
             echo "$GCLOUD_SERVICE_KEY" | \
               gcloud auth activate-service-account \
                 circleci-image-uploader@opensourcecoin.iam.gserviceaccount.com \
                 --key-file=-
-
-            version="$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
-            VERSION=$version TARGET=darwin ./packaging/build-package.sh
             if [ "$CIRCLE_BRANCH" == "master" ]; then
               # Upload package aliases for easier distribution
               cp  \
@@ -113,4 +119,5 @@ jobs:
                 "packaging/out/radicle_${version}_x86_64-darwin.tar.gz" \
                 "packaging/out/radicle_latest_x86_64-darwin.tar.gz"
             fi
+
             ./packaging/upload.sh


### PR DESCRIPTION
Before, the “Package” step failed because GCLOUD_SERVICE_KEY is not available to builds of forks. We make the step pass for forks by skipping upload