### PR TITLE
Minimize dockerfile and image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -20,7 +20,7 @@ RUN \
     > /etc/apt/sources.list.d/google-cloud-sdk.list && \
   apt-key add google-apt-key.gpg && \
   apt-get update -yqq && \
-  apt-get -yq install \
+  apt-get -yq --no-install-recommends install \
     build-essential \
     ruby \
     ruby-dev \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 timeout: 3600s # Cache misses are slow to rebuild
 substitutions:
   # Bump the version if you make changes to `ci/Dockerfile
-  _BUILD_IMAGE: eu.gcr.io/opensourcecoin/radicle-ci:v3
+  _BUILD_IMAGE: eu.gcr.io/opensourcecoin/radicle-ci:v4
 options:
   machineType: N1_HIGHCPU_8
 steps:


### PR DESCRIPTION
Courtesy of @stephengroat in #558

This PR contains the changes of #558 in a branch in our own repo so that the Google Cloud Build runs.