### PR TITLE
Move to brew bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,8 @@ jobs:
       - run:
           name: Homebrew Dependencies
           command: |
-            brew install coreutils
+            brew bundle
             echo 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"' >> $BASH_ENV
-            brew tap caskroom/cask
-            brew cask install google-cloud-sdk
 
       - save_cache:
           key: homebrew-{{ epoch }}

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew 'coreutils'
+cask 'google-cloud-sdk'


### PR DESCRIPTION
`brew install` generates an error if the package is already installed and can create havoc for CI system when the base image changes
`brew bundle` is now included in homebrew and allows for textual configurations to be moved out of ci scripts and into the main repo for those developing on osx