### PR TITLE
Improve item-number parsing and add mark-read command

### DIFF
--- a/bin/rad-issue
+++ b/bin/rad-issue
@@ -241,13 +241,13 @@
     (newness/mark-read! machine n)))
 
 (def close-issue
-  (fn [issue-number machine]
+  (fn [n machine]
     (catch 'daemon-error
-        (do
-          (verify-issue-number n machine)
-          (simple-edit-issue! machine n {:state :closed})
-          (put-str! (string-append "Issue #" (show n) " has been closed."))
-          (newness/mark-read! machine n))
+      (do
+        (verify-issue-number n machine)
+        (simple-edit-issue! machine n {:state :closed})
+        (put-str! (string-append "Issue #" (show n) " has been closed."))
+        (newness/mark-read! machine n))
       (fn [_]
         (put-str! (error/state-change-failure :issue "closed"))
         (exit! 1)))))
@@ -290,7 +290,7 @@
 
 (def whole-issue-num
   (fn [action num-str f]
-    (whole-num :issue action num-str f)))
+    (whole-num help :issue action num-str f)))
 
 (machine/catch-daemon!
  (fn []

--- a/bin/rad-issue
+++ b/bin/rad-issue
@@ -236,44 +236,29 @@
 (def show-issue!
   "Shows a single ISSUE `n`"
   (fn [n machine]
-    (if (number? n)
-      (if (integral? n)
-        (do
-          (def issue (verify-issue-number n machine))
-          (put-str! (pretty-issue (enrich-issue machine issue)))
-          (newness/mark-read! machine n))
-        (cmd-parse-failure (error/whole-item-number :issue)))
-      (cmd-parse-failure (error/missing-item-number :issue "show")))))
+    (def issue (verify-issue-number n machine))
+    (put-str! (pretty-issue (enrich-issue machine issue)))
+    (newness/mark-read! machine n)))
 
 (def close-issue
   (fn [issue-number machine]
-    (def n (read issue-number))
-    (if (number? n)
-      (if (integral? n)
-        (catch 'daemon-error
-               (do
-                 (verify-issue-number n machine)
-                 (simple-edit-issue! machine n {:state :closed})
-                 (put-str! (string-append "Issue #" (show n) " has been closed."))
-                 (newness/mark-read! machine n))
-               (fn [_]
-                 (put-str! (error/state-change-failure :issue "closed"))
-                 (exit! 1)))
-        (cmd-parse-failure (error/whole-item-number :issue)))
-      (cmd-parse-failure (error/missing-item-number :issue "close")))))
+    (catch 'daemon-error
+        (do
+          (verify-issue-number n machine)
+          (simple-edit-issue! machine n {:state :closed})
+          (put-str! (string-append "Issue #" (show n) " has been closed."))
+          (newness/mark-read! machine n))
+      (fn [_]
+        (put-str! (error/state-change-failure :issue "closed"))
+        (exit! 1)))))
 
 (def create-comment!
   "Add a new `comment` to ISSUE."
   (fn [machine n comment]
-    (if (number? n)
-      (if (integral? n)
-        (do
-          (verify-issue-number n machine)
-          (simple-add-comment! machine n comment (get-git-username!))
-          (put-str! (string-append "Added comment to issue #" (show n)))
-          (newness/mark-read! machine n))
-        (cmd-parse-failure (error/whole-item-number :issue)))
-    (cmd-parse-failure (error/missing-item-number :issue "comment on")))))
+    (verify-issue-number n machine)
+    (simple-add-comment! machine n comment (get-git-username!))
+    (put-str! (string-append "Added comment to issue #" (show n)))
+    (newness/mark-read! machine n)))
 
 (def new-issue
   (fn [machine]
@@ -303,14 +288,19 @@
 
 (def args (get-args!))
 
+(def whole-issue-num
+  (fn [action num-str f]
+    (whole-num :issue action num-str f)))
+
 (machine/catch-daemon!
  (fn []
    (match args
           (/list-cmd 'options) (list-items (machine-name) options)
           (/cmd-0 "new" help) (new-issue (machine-name))
-          (/cmd-1 "close" 'issue-number help) (close-issue issue-number (machine-name))
-          (/cmd-1 "show" 'issue-number help) (show-issue! (read issue-number) (machine-name))
-          (/cmd-2 "comment" 'issue-number 'comment help) (create-comment! (machine-name) (read issue-number) comment)
+          (/cmd-1 "close" 'n help)            (whole-issue-num "close" n (fn [n] (close-issue n (machine-name))))
+          (/cmd-1 "show" 'n help)             (whole-issue-num "show" n (fn [n] (show-issue! n (machine-name))))
+          (/cmd-2 "comment" 'n 'comment help) (whole-issue-num "comment on" n (fn [n] (create-comment! (machine-name) n comment)))
+          (/cmd-1 "mark-read" 'n help)        (whole-issue-num "mark as read" n (fn [n] (newness/mark-read! (machine-name) n)))
           ["help"] (put-str! help)
           ["-h"] (put-str! help)
           ["--help"] (put-str! help)

--- a/bin/rad-patch
+++ b/bin/rad-patch
@@ -326,55 +326,40 @@
 (def show-patch!
   "Shows a single PATCH `n`"
   (fn [machine n]
-    (if (number? n)
-      (if (integral? n)
-        (do
-          (def patch (verify-patch-number n machine))
-          (put-str! (pretty-patch (add-read-status! machine patch)))
-          (newness/mark-read! machine n))
-        (cmd-parse-failure (error/whole-item-number :patch)))
-      (cmd-parse-failure (error/missing-item-number :patch "show")))))
+    (def patch (verify-patch-number n machine))
+    (put-str! (pretty-patch (add-read-status! machine patch)))
+    (newness/mark-read! machine n)))
 
 (def edit-patch-state!
   "Edit the state of a PATCH. If the new state is `:accepted` the PATCH is then
   also merged to master and the changes pushed."
   (fn [machine n new-state]
-    (if (number? n)
-      (if (integral? n)
-        (do
-          (def edit-state-with-feedback!
-            (fn [message]
-              (catch 'daemon-error
-                (do (simple-edit-patch! machine n {:state new-state})
-                    (newness/mark-read! machine n))
-                (fn [x]
-                   (put-str!
-                     (error/state-change-failure :patch (pretty-state new-state)))
-                   (exit! 1)))
-              (put-str! message)))
-          (verify-patch-number n machine)
-          (if (eq? new-state :accepted)
-            (match (push-patch! machine n)
-              :ok (edit-state-with-feedback!
-                    (string-append "Patch #" (show n) " has been " (pretty-state new-state) " and merged."))
-              _   (exit! 1))
-            (edit-state-with-feedback!
-              (string-append "Patch #" (show n) " has been " (pretty-state new-state)))))
-        (cmd-parse-failure (error/whole-item-number :patch)))
-    (cmd-parse-failure (error/missing-item-number :patch "change the state of")))))
+    (def edit-state-with-feedback!
+      (fn [message]
+        (catch 'daemon-error
+            (do (simple-edit-patch! machine n {:state new-state})
+                (newness/mark-read! machine n))
+          (fn [x]
+            (put-str!
+             (error/state-change-failure :patch (pretty-state new-state)))
+            (exit! 1)))
+        (put-str! message)))
+    (verify-patch-number n machine)
+    (if (eq? new-state :accepted)
+      (match (push-patch! machine n)
+             :ok (edit-state-with-feedback!
+                  (string-append "Patch #" (show n) " has been " (pretty-state new-state) " and merged."))
+             _   (exit! 1))
+      (edit-state-with-feedback!
+       (string-append "Patch #" (show n) " has been " (pretty-state new-state))))))
 
 (def create-comment!
   "Add a new `comment` to PATCH."
   (fn [machine n comment]
-    (if (number? n)
-      (if (integral? n)
-        (do
-          (verify-patch-number n machine)
-          (simple-add-comment! machine n comment (get-git-username!))
-          (put-str! (string-append "Added comment to patch #" (show n)))
-          (newness/mark-read! machine n))
-        (cmd-parse-failure (error/whole-item-number :patch)))
-    (cmd-parse-failure (error/missing-item-number :patch "comment on")))))
+    (verify-patch-number n machine)
+    (simple-add-comment! machine n comment (get-git-username!))
+    (put-str! (string-append "Added comment to patch #" (show n)))
+    (newness/mark-read! machine n)))
 
 (def cmd-options
   [
@@ -386,6 +371,10 @@
   (fn [opts]
     (/cmd-opts "list" opts cmd-options help)))
 
+(def whole-patch-num
+  (fn [action num-str f]
+    (whole-num :patch action num-str f)))
+
 (def args (get-args!))
 
 (machine/catch-daemon!
@@ -393,12 +382,13 @@
    (match args
           (/list-cmd 'options) (list-items (machine-name) options)
           (/cmd-1 "propose" 'commit help) (new-patch! (machine-name) commit)
-          (/cmd-1 "checkout" 'patch-number help) (checkout-patch! (machine-name) (read patch-number))
-          (/cmd-1 "show" 'patch-number help) (show-patch! (machine-name) (read patch-number))
-          (/cmd-1 "retract" 'patch-number help) (edit-patch-state! (machine-name) (read patch-number) :retracted)
-          (/cmd-1 "accept" 'patch-number help) (edit-patch-state! (machine-name) (read patch-number) :accepted)
-          (/cmd-1 "reject" 'patch-number help) (edit-patch-state! (machine-name) (read patch-number) :rejected)
-          (/cmd-2 "comment" 'patch-number 'comment help) (create-comment! (machine-name) (read patch-number) comment)
+          (/cmd-1 "checkout" 'n help)  (whole-patch-num "checkout" n (fn [n] (checkout-patch! (machine-name) n)))
+          (/cmd-1 "show" 'n help)      (whole-patch-num "show" n (fn [n] (show-patch! (machine-name) n)))
+          (/cmd-1 "mark-read" 'n help) (whole-patch-num "mark as read" n (fn [n] (newness/mark-read! (machine-name) n)))
+          (/cmd-1 "retract" 'n help)   (whole-patch-num "retract" n (fn [n] (edit-patch-state! (machine-name) n :retracted)))
+          (/cmd-1 "accept" 'n help)    (whole-patch-num "accept" n (fn [n] (edit-patch-state! (machine-name) n :accepted)))
+          (/cmd-1 "reject" 'n help)    (whole-patch-num "reject" n (fn [n] (edit-patch-state! (machine-name) n :rejected)))
+          (/cmd-2 "comment" 'n 'comment help) (whole-patch-num "comment on" (fn [n] (create-comment! (machine-name) n comment)))
           (/cmd-0 "create-machine" help) (new-patch-machine! (machine-name))
           ["help"] (put-str! help)
           ["-h"] (put-str! help)

--- a/bin/rad-patch
+++ b/bin/rad-patch
@@ -373,7 +373,7 @@
 
 (def whole-patch-num
   (fn [action num-str f]
-    (whole-num :patch action num-str f)))
+    (whole-num help :patch action num-str f)))
 
 (def args (get-args!))
 
@@ -388,7 +388,7 @@
           (/cmd-1 "retract" 'n help)   (whole-patch-num "retract" n (fn [n] (edit-patch-state! (machine-name) n :retracted)))
           (/cmd-1 "accept" 'n help)    (whole-patch-num "accept" n (fn [n] (edit-patch-state! (machine-name) n :accepted)))
           (/cmd-1 "reject" 'n help)    (whole-patch-num "reject" n (fn [n] (edit-patch-state! (machine-name) n :rejected)))
-          (/cmd-2 "comment" 'n 'comment help) (whole-patch-num "comment on" (fn [n] (create-comment! (machine-name) n comment)))
+          (/cmd-2 "comment" 'n 'comment help) (whole-patch-num "comment on" n (fn [n] (create-comment! (machine-name) n comment)))
           (/cmd-0 "create-machine" help) (new-patch-machine! (machine-name))
           ["help"] (put-str! help)
           ["-h"] (put-str! help)

--- a/rad/prelude/cmd-parsing.rad
+++ b/rad/prelude/cmd-parsing.rad
@@ -172,11 +172,24 @@
   "Try to parse an argument which should be a whole-number. If parsed succesfully
   the integer is passed to handler function. If not, an error is show to the
   user."
-  (fn [item action num-str f]
-    (def bad (fn [] (cmd-parse-failure (error/missing-item-number item action))))
+  (fn [help item action num-str f]
+    (def bad (fn [] (parse-failure (error/missing-item-number item action) help)))
     (def n (catch 'any (read num-str) (fn [_] (bad))))
     (if (number? n)
       (if (integral? n)
         (f n)
-        (not-whole))
-      (cmd-parse-failure (error/missing-item-number item action)))))
+        (parse-failure (error/whole-item-number :issue) help))
+      (parse-failure (error/missing-item-number item action) help))))
+
+(:test "whole-num"
+  [:setup
+   (do
+     (set-ref parse-failure-mode (@ :stub) #t)
+     (def inc (fn [n] (+ 1 n)))) ]
+  [ (whole-num "help" :issue "show" "0" inc) ==> 1 ]
+  [ (catch 'invalid-input
+      (whole-num "help" :issue "show" "1/2" inc)
+      (fn [x] x)) ==> "Issue numbers must be whole numbers! help" ==> ]
+  [ (catch 'invalid-input
+      (whole-num "help" :issue "show" "0.1" inc)
+      (fn [x] x)) ==> "To show an issue, please provide the issue number. help" ==> ])

--- a/rad/prelude/cmd-parsing.rad
+++ b/rad/prelude/cmd-parsing.rad
@@ -1,7 +1,7 @@
 {:module 'prelude/cmd-parsing
  :doc "Functions for parsing commands."
  :exports
- '[parse-failure /cmd-0 /cmd-1 /cmd-2 /cmd-opts]}
+ '[parse-failure /cmd-0 /cmd-1 /cmd-2 /cmd-opts whole-num]}
 
 (import prelude/basic :unqualified)
 (import prelude/dict :unqualified)
@@ -167,3 +167,16 @@
   [ (/cmd ["cmd-0"]) ==> [:just {}]]
   [ (/cmd ["cmd-1"]) ==> :nothing]
   [ (catch-for-testing /cmd ["cmd-0" 1]) ==> "Too many arguments for command \"cmd-0\" help"])
+
+(def whole-num
+  "Try to parse an argument which should be a whole-number. If parsed succesfully
+  the integer is passed to handler function. If not, an error is show to the
+  user."
+  (fn [item action num-str f]
+    (def bad (fn [] (cmd-parse-failure (error/missing-item-number item action))))
+    (def n (catch 'any (read num-str) (fn [_] (bad))))
+    (if (number? n)
+      (if (integral? n)
+        (f n)
+        (not-whole))
+      (cmd-parse-failure (error/missing-item-number item action)))))


### PR DESCRIPTION
- Removes duplicate code for checking `number?` and `integral?`.
- Adds checks to some places that were missing.
- Improves checking (catching `read` exceptions).
- Adds `mark-read` cmd to issues and patches.
- Makes action descriptions in some errors more specific.