### PR TITLE
List open/pending issues/patches by default.

### DIFF
--- a/bin/rad-issue
+++ b/bin/rad-issue
@@ -6,7 +6,10 @@
 (load! (find-module-file! "prelude/io-utils.rad"))
 
 (file-module! "prelude/error-messages.rad")
+(file-module! "monadic/items.rad")
+
 (import prelude/error-messages :as 'error)
+(import monadic/items :as 'items)
 
 (import prelude/validation :as 'validation)
 (import prelude/machine :as 'machine)
@@ -193,6 +196,8 @@
           [(pretty-headline i) i]
           [(pretty-row i) i])))
 
+    (def issues (values (list-issues machine)))
+
     (def filt
       (match (map (fn [opt] (read (string-append ":" opt))) (lookup :state options))
         []      (fn [x] #t)
@@ -202,7 +207,7 @@
       (map mk-key
           (map (fn [i] (enrich-issue machine i))
                (filter filt
-                       (reverse (values (list-issues machine)))))))
+                       (reverse issues)))))
 
     (def items-dict (dict-from-seq items))
     (if (empty-seq? items)
@@ -231,7 +236,8 @@
                _ (put-str! "No selection made."))
         (do
           (put-str! (pretty-table-header))
-          (map (fn [d] (put-str! (first d))) items))))))
+          (map (fn [d] (put-str! (first d))) items)
+          (put-str! (items/summary "issues" issues)))))))
 
 (def show-issue!
   "Shows a single ISSUE `n`"

--- a/bin/rad-issue
+++ b/bin/rad-issue
@@ -278,7 +278,7 @@
 
 (def cmd-options
   [
-    { :key :state :type :multi-opt :options ["-s" "--state" "--filter-by-state"] :possible-values valid-states :default []}
+    { :key :state :type :multi-opt :options ["-s" "--state" "--filter-by-state"] :possible-values valid-states :default ["open"]}
     { :key :fancy :type :flag :options ["--fancy"] :default #f }
   ])
 

--- a/bin/rad-patch
+++ b/bin/rad-patch
@@ -6,7 +6,10 @@
 (load! (find-module-file! "monadic/project.rad"))
 
 (file-module! "prelude/error-messages.rad")
+(file-module! "monadic/items.rad")
+
 (import prelude/error-messages :as 'error)
+(import monadic/items :as 'items)
 
 (import prelude/validation :as 'validation)
 
@@ -289,11 +292,13 @@
         []      (fn [x] #t)
         'args   (fn [x] (elem? (lookup :state x) args))))
 
+    (def patches (values (list-patches machine)))
+
   (def items
     (map mk-key
          (map (fn [i] (add-read-status! machine i))
               (filter filt
-                      (reverse (values (list-patches machine)))))))
+                      (reverse patches)))))
 
     (def items-dict (dict-from-seq items))
     (if (empty-seq? items)
@@ -321,7 +326,8 @@
                _ (put-str! "No selection made."))
          (do
            (put-str! (pretty-table-header))
-           (map (fn [d] (put-str! (first d))) items))))))
+           (map (fn [d] (put-str! (first d))) items)
+           (put-str! (items/summary "patches" patches)))))))
 
 (def show-patch!
   "Shows a single PATCH `n`"

--- a/bin/rad-patch
+++ b/bin/rad-patch
@@ -363,7 +363,7 @@
 
 (def cmd-options
   [
-    { :key :state :type :multi-opt :options status-opts :possible-values valid-states :default []}
+    { :key :state :type :multi-opt :options status-opts :possible-values valid-states :default ["pending"]}
     { :key :fancy :type :flag :options ["--fancy"] :default #f }
   ])
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1070,8 +1070,9 @@ and ``:nothing`` otherwise.
 ``(group-by f xs)``
 ~~~~~~~~~~~~~~~~~~~
 
-Partitions the values in a sequence ``xs``. The partitions are returns
-in a dict keyed by the return value of ``f``.
+Partitions the values of a sequence ``xs`` according to the images under
+``f``. The partitions are returned in a dict keyed by the return value
+of ``f``.
 
 ``prelude/io``
 --------------

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1067,6 +1067,12 @@ Like ``lookup`` but returns ``default`` if the key is not in the map.
 Like ``lookup`` but returns ``[:just x]`` if the key is not in the map
 and ``:nothing`` otherwise.
 
+``(group-by f xs)``
+~~~~~~~~~~~~~~~~~~~
+
+Partitions the values in a sequence ``xs``. The partitions are returns
+in a dict keyed by the return value of ``f``.
+
 ``prelude/io``
 --------------
 

--- a/rad/monadic/items.rad
+++ b/rad/monadic/items.rad
@@ -1,0 +1,22 @@
+{:module  'monadic/items
+ :doc     "Functions for interacting with dicts of items in machines"
+ :exports '[summary]}
+
+(def summary
+  "Given a list of `items`, each a dict with a `:state` key, displays a summary of
+  how many items there are of each state."
+  (fn [items-name items]
+    (string-append
+     "\n"
+     (show (length items))
+     " "
+     items-name
+     ": "
+     (string/intercalate
+      ", "
+      (map (fn [kv]
+             (string-append (show (length (nth 1 kv)))
+                            " "
+                            (drop 1 (show (nth 0 kv)))))
+           (seq (group-by (fn [i] (lookup :state i))
+                          items)))))))

--- a/rad/prelude/cmd-parsing.rad
+++ b/rad/prelude/cmd-parsing.rad
@@ -97,18 +97,19 @@
           { :key :state :type :multi-opt :options ["-s" "--state" "--filter-by-state"] :possible-values ["acc" "prop"] :default []}
           { :key :fancy :type :flag :options ["--fancy"] :default #f }
          ])
-      (def cmd-opts2
+      (def cmd-opts-2
         [
           { :key :state :type :multi-opt :options ["-s" "--state" "--filter-by-state"] :possible-values ["acc" "prop"] :default ["acc"]}
           { :key :fancy :type :flag :options ["--fancy"] :default #f }
         ])
-      (def /cmd (/cmd-opts "list" 'opts cmd-opts help)))]
+      (def /cmd (/cmd-opts "list" 'opts cmd-opts help))
+      (def /cmd-2 (/cmd-opts "list" 'opts cmd-opts-2 help)))]
   [(/cmd ["list"] ) ==> [:just {opts {:state [] :fancy #f}}]]
-  [(/cmd ["list"] ) ==> [:just {opts {:state ["acc"] :fance #f}}]]
+  [(/cmd-2 ["list"] ) ==> [:just {opts {:state ["acc"] :fancy #f}}]]
   [(/cmd ["list" "--fancy"] ) ==> [:just {opts {:state [] :fancy #t}}]]
   [(/cmd ["list" "--state" "acc"] ) ==> [:just {opts {:state ["acc"] :fancy #f}}]]
   [(/cmd ["list" "--fancy" "-s" "acc"] ) ==> [:just {opts {:state ["acc"] :fancy #t}}]]
-  [(/cmd ["list" "--fancy" "-s" "prop"]) ==> [:just {opts {:state ["prop"] :fancy #t}}]]
+  [(/cmd-2 ["list" "--fancy" "-s" "prop"]) ==> [:just {opts {:state ["prop"] :fancy #t}}]]
   [(/cmd ["list" "--state" "prop" "-s" "acc"] ) ==> [:just {opts {:state ["prop" "acc"] :fancy #f}}]]
   [(catch-for-testing /cmd ["list" "--invalid" "prop"] ) ==> "Invalid option \"--invalid\" for command list. help"]
   [(catch-for-testing /cmd ["list" "prop"] ) ==> "Invalid option \"prop\" for command list. help"]

--- a/rad/prelude/cmd-parsing.rad
+++ b/rad/prelude/cmd-parsing.rad
@@ -38,6 +38,13 @@
   once in a command, a list of valid options is passed with `:possible-values`).
   If `opt` is empty, the default for each `cmd-opts` is returned. "
   (fn [cmd opts cmd-opts help]
+    (def empty-opts
+      (dict-from-seq
+       (map (fn [opt]
+              (match opt
+                     {:key 'k :type :multi-opt} [k []]
+                     {:key 'k :default 'd}      [k d]))
+            cmd-opts)))
     (def default
       (dict-from-seq
         (map (fn [opt] (list (lookup :key opt) (lookup :default opt))) cmd-opts)))
@@ -72,8 +79,8 @@
               (insert (lookup :key option) #t (parse-cli rest))
               (parse-arg option rest))))
         (match args
-          /nil                default
-          (/cons 'opt 'rest)  (parse-opt opt rest))))
+          /nil               empty-opts
+          (/cons 'opt 'rest) (parse-opt opt rest))))
     (fn [v]
       (match v
         [cmd]           [:just {opts default}]
@@ -89,12 +96,19 @@
         [
           { :key :state :type :multi-opt :options ["-s" "--state" "--filter-by-state"] :possible-values ["acc" "prop"] :default []}
           { :key :fancy :type :flag :options ["--fancy"] :default #f }
+         ])
+      (def cmd-opts2
+        [
+          { :key :state :type :multi-opt :options ["-s" "--state" "--filter-by-state"] :possible-values ["acc" "prop"] :default ["acc"]}
+          { :key :fancy :type :flag :options ["--fancy"] :default #f }
         ])
       (def /cmd (/cmd-opts "list" 'opts cmd-opts help)))]
   [(/cmd ["list"] ) ==> [:just {opts {:state [] :fancy #f}}]]
+  [(/cmd ["list"] ) ==> [:just {opts {:state ["acc"] :fance #f}}]]
   [(/cmd ["list" "--fancy"] ) ==> [:just {opts {:state [] :fancy #t}}]]
   [(/cmd ["list" "--state" "acc"] ) ==> [:just {opts {:state ["acc"] :fancy #f}}]]
   [(/cmd ["list" "--fancy" "-s" "acc"] ) ==> [:just {opts {:state ["acc"] :fancy #t}}]]
+  [(/cmd ["list" "--fancy" "-s" "prop"]) ==> [:just {opts {:state ["prop"] :fancy #t}}]]
   [(/cmd ["list" "--state" "prop" "-s" "acc"] ) ==> [:just {opts {:state ["prop" "acc"] :fancy #f}}]]
   [(catch-for-testing /cmd ["list" "--invalid" "prop"] ) ==> "Invalid option \"--invalid\" for command list. help"]
   [(catch-for-testing /cmd ["list" "prop"] ) ==> "Invalid option \"prop\" for command list. help"]

--- a/rad/prelude/dict.rad
+++ b/rad/prelude/dict.rad
@@ -1,6 +1,6 @@
 {:module  'prelude/dict
  :doc     "Functions for manipualting dicts."
- :exports '[dict-from-seq keys values rekey modify-map delete-many lookup-default lookup-maybe]}
+ :exports '[dict-from-seq keys values rekey modify-map delete-many lookup-default lookup-maybe group-by]}
 
 (import prelude/patterns :unqualified)
 
@@ -76,3 +76,13 @@
 (:test "lookup-default"
   [ (lookup-default :one 2 {:one 1}) ==> 1 ]
   [ (lookup-default :two 2 {:one 1}) ==> 2 ])
+
+(def group-by
+  (fn [f xs]
+    (foldr (fn [x acc]
+             (def k (f x))
+             (match (lookup-maybe k acc)
+                    [:just 'ys] (insert k (cons x ys) acc)
+                    :nothing    (insert k [x] acc)))
+           {}
+           xs)))

--- a/rad/prelude/dict.rad
+++ b/rad/prelude/dict.rad
@@ -78,8 +78,8 @@
   [ (lookup-default :two 2 {:one 1}) ==> 2 ])
 
 (def group-by
-  "Partitions the values in a sequence `xs`. The partitions are returns in a dict
-  keyed by the return value of `f`."
+  "Partitions the values of a sequence `xs` according to the images under `f`. The
+  partitions are returned in a dict keyed by the return value of `f`."
   (fn [f xs]
     (foldr (fn [x acc]
              (def k (f x))

--- a/rad/prelude/dict.rad
+++ b/rad/prelude/dict.rad
@@ -78,6 +78,8 @@
   [ (lookup-default :two 2 {:one 1}) ==> 2 ])
 
 (def group-by
+  "Partitions the values in a sequence `xs`. The partitions are returns in a dict
+  keyed by the return value of `f`."
   (fn [f xs]
     (foldr (fn [x acc]
              (def k (f x))
@@ -86,3 +88,9 @@
                     :nothing    (insert k [x] acc)))
            {}
            xs)))
+
+(:test "group-by"
+       [ (group-by length []) ==> {} ]
+       [ (group-by length ["foo" "foofoo" "bar" "foobar" "bar" "barbar"]) ==> {3 ["foo" "bar" "bar"]
+                                                                               6 ["foofoo" "foobar" "barbar"]} ]
+       )

--- a/rad/prelude/patterns.rad
+++ b/rad/prelude/patterns.rad
@@ -54,27 +54,31 @@
     (def /vec
       (fn [pats]
         (fn [v]
-          (if (eq? (length v) (length pat))
-            (maybe-foldlM
-             (fn [acc pair]
-               (maybe->>= (match-pat (nth 0 pair) (nth 1 pair))
-                          (fn [bs] (non-linear-merge acc bs))))
-             {}
-             (zip pats v))
+          (if (or (vector? v) (list? v))
+            (if (eq? (length v) (length pat))
+              (maybe-foldlM
+               (fn [acc pair]
+                 (maybe->>= (match-pat (nth 0 pair) (nth 1 pair))
+                            (fn [bs] (non-linear-merge acc bs))))
+               {}
+               (zip pats v))
+              :nothing)
             :nothing))))
     (def /dict
       (fn [keys-pat]
         (fn [d]
-          (maybe-foldlM
-           (fn [acc kv]
-             (def k (nth 0 kv))
-             (def pat (nth 1 kv))
-             (if (member? k d)
-               (maybe->>= (match-pat pat (lookup k d))
-                          (fn [bs] (non-linear-merge acc bs)))
-               :nothing))
-           {}
-           (seq keys-pat)))))
+          (if (dict? d)
+            (maybe-foldlM
+             (fn [acc kv]
+               (def k (nth 0 kv))
+               (def pat (nth 1 kv))
+               (if (member? k d)
+                 (maybe->>= (match-pat pat (lookup k d))
+                            (fn [bs] (non-linear-merge acc bs)))
+                 :nothing))
+             {}
+             (seq keys-pat))
+            :nothing))))
     (cond
       (atom? pat)
       [:just {pat v}]


### PR DESCRIPTION
- Listing issues and patches only shows open/pending items by default.
- Fix bug in options command parsing to allow choosing other than a superset of the default set.
- Summary of number of items by state is printed at the end of list.
- Fix bug in pattern matching where values would fail to match if they are the wrong type.