### PR TITLE
Prevent race conditions when loading machines

### DIFF
--- a/src/Radicle/Daemon/MachineStore.hs
+++ b/src/Radicle/Daemon/MachineStore.hs
@@ -12,6 +12,7 @@ module Radicle.Daemon.MachineStore
   , CachedMachines(..)
   , MonadMachineStore(..)
   , modifyMachine
+  , modifyMachine'
   , insertMachine
   , insertUninitializedReader
   , emptyMachine
@@ -98,6 +99,11 @@ modifyMachine id f = do
         Cached m -> do
             (m', a) <- f m
             pure (Cached m', a)
+
+modifyMachine' :: forall a m. (MonadMachineStore m) => MachineId -> (Maybe CachedMachine -> m (Maybe CachedMachine, a)) -> m a
+modifyMachine' id f = do
+    machines <- askMachines
+    CMap.modifyValue id (getMachines machines) f
 
 emptyMachine :: (MonadMachineStore m) => MachineId -> ReaderOrWriter -> TopicSubscription -> m Machine
 emptyMachine id mode sub = liftIO $ do


### PR DESCRIPTION
This commit prevents race conditions when initiating two concurrent queries two an machine that is not yet loaded. Concurrent queries would lead to concurrent calls to `ensureMachineLoaded`. Before both calls would receive `Nothing` from `lookupMachine` and would start the loading process. We prevent this with the following changes

* `ensureMachineLoaded` uses `modifyMachine'` so that invocations are serialized.
* `loadMachine` does not insert the machine into the store
* `refreshAsReader` has been renamed `pullStoreInputs`. The function is extended to writer machines in which case it is a no-op