### PR TITLE
Fix ipfs-test-network image to working version

### DIFF
--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 
 services:
   ipfs-test-network:
-    image: gcr.io/opensourcecoin/ipfs-test-network
+    image: gcr.io/opensourcecoin/ipfs-test-network@sha256:2f6738237b3859593b2c83084a79bd642b5e61662a28dc34a2c92f687c53a4d1
     ports:
     - "19301:5001"
     command:


### PR DESCRIPTION
We fix the version of the `ipfs-test-network` image. The latest one upgraded to IPFS v0.4.19 which does not seem to work with `git-remote-ipfs`.