### PR TITLE
Make to-json work on more inputs.

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -445,7 +445,12 @@ right now, formatted according to ISO 8601.
 ``to-json``
 ~~~~~~~~~~~
 
-Returns a JSON formatted string representing the input value.
+Returns a JSON formatted string representing the input value. Numbers
+are only converted if they have a finite decimal expansion. Strings and
+booleans are converted to their JSON counterparts. Keywords are
+converted to JSON strings (dropping the initial ':'). Lists and vectors
+are converted to JSON arrays. Dicts are converted to JSON objects as
+long as all the keys are either strings of keywords.
 
 ``uuid!``
 ~~~~~~~~~

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -450,7 +450,7 @@ are only converted if they have a finite decimal expansion. Strings and
 booleans are converted to their JSON counterparts. Keywords are
 converted to JSON strings (dropping the initial ':'). Lists and vectors
 are converted to JSON arrays. Dicts are converted to JSON objects as
-long as all the keys are either strings of keywords.
+long as all the keys are either strings or keywords.
 
 ``uuid!``
 ~~~~~~~~~

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -565,7 +565,12 @@ purePrimFns = fromList $ allDocs $
             v -> throwErrorHere $ TypeError "seq" 0 TStructure v
       )
     , ( "to-json"
-      , "Returns a JSON formatted string representing the input value."
+      , "Returns a JSON formatted string representing the input value. Numbers are only\
+        \ converted if they have a finite decimal expansion. Strings and booleans are\
+        \ converted to their JSON counterparts. Keywords are converted to JSON strings\
+        \ (dropping the initial ':'). Lists and vectors are converted to JSON arrays.\
+        \ Dicts are converted to JSON objects as long as all the keys are either\
+        \ strings of keywords."
       , oneArg "to-json" $ \v -> String . toS . Aeson.encode <$>
           maybeJson v ?? toLangError (OtherError "Could not serialise value to JSON")
       )

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -570,7 +570,7 @@ purePrimFns = fromList $ allDocs $
         \ converted to their JSON counterparts. Keywords are converted to JSON strings\
         \ (dropping the initial ':'). Lists and vectors are converted to JSON arrays.\
         \ Dicts are converted to JSON objects as long as all the keys are either\
-        \ strings of keywords."
+        \ strings or keywords."
       , oneArg "to-json" $ \v -> String . toS . Aeson.encode <$>
           maybeJson v ?? toLangError (OtherError "Could not serialise value to JSON")
       )

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -476,7 +476,9 @@ test_eval =
 
     , testCase "'to-json' works" $ do
         runPureCode "(to-json (dict \"foo\" #t))" @?= Right (String "{\"foo\":true}")
+        runPureCode "(to-json {:foo #t \"bar\" #f})" @?= Right (String "{\"foo\":true,\"bar\":false}")
         runPureCode "(to-json (dict \"key\" (list 1 \"value\")))" @?= Right (String "{\"key\":[1,\"value\"]}")
+        runPureCode "(to-json [3/2 #f])" @?= Right (String "[1.5,false]")
         noStack (runPureCode "(to-json (dict 1 2))") @?= Left (OtherError "Could not serialise value to JSON")
 
     , testCase "def-rec can define recursive functions" $ do


### PR DESCRIPTION
Now also converts:
- vectors,
- keywords,
- dicts with mixed string/keyword keys.