### PR TITLE
tests: Wait for IPFS test network to be ready

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -170,29 +170,9 @@ steps:
 
       RADPATH="$(pwd)/rad" stack exec radicle-doc docs/source/guide/Basics.lrad
 
-  - id: "Start IPFS daemon"
-    name: $_BUILD_IMAGE
-    entrypoint: bash
-    args:
-    - "-c"
-    - |
-      set -euxo pipefail
-
-      export COMPOSE_FILE=test/docker-compose.yaml
-      docker-compose up -d
-      sleep 3 # Wait for service to be booted
-
-      # Connect services to 'cloudbuild' network so they can be
-      # accessed by other steps
-      docker network connect cloudbuild test_ipfs-test-network_1 --alias ipfs-test-network
-
-      # Add the empty entry to the IPFS test network. Radicle requires it
-      echo '{"radicle": true}' | docker exec -i test_ipfs-test-network_1 ipfs dag put --pin
-
-
   - id: "Integration tests"
     waitFor:
-    - "Start IPFS daemon"
+    - "Build"
     name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: 'bash'
@@ -201,17 +181,24 @@ steps:
     - |
       set -euxo pipefail
 
+      export COMPOSE_FILE=test/docker-compose.yaml
+      docker-compose up -d
+      sleep 1 # Wait for containers to be started
+
+      # Connect services to 'cloudbuild' network so they can be
+      # accessed by other steps
+      docker network connect cloudbuild test_ipfs-test-network_1 --alias ipfs-test-network
+      docker exec test_ipfs-test-network_1 /app/wait-until-ready
+
+      # Add the empty entry to the IPFS test network. Radicle requires it
+      echo '{"radicle": true}' | docker exec -i test_ipfs-test-network_1 ipfs dag put --pin
+
       export RAD_IPFS_API_URL=http://ipfs-test-network:5001
       export RADPATH="$(pwd)/rad"
 
       stack exec -- rad-daemon-radicle &
 
-      stack test :e2e || {
-        # Get some debugging information from the IPFS container
-        docker exec test_ipfs-test-network_1 ipfs swarm peers
-        docker logs test_ipfs-test-network_1
-        false
-      }
+      stack test :e2e
 
   - id: "Package"
     waitFor:

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 
 services:
   ipfs-test-network:
-    image: gcr.io/opensourcecoin/ipfs-test-network@sha256:2f6738237b3859593b2c83084a79bd642b5e61662a28dc34a2c92f687c53a4d1
+    image: gcr.io/opensourcecoin/ipfs-test-network:010c506
     ports:
     - "19301:5001"
     command:


### PR DESCRIPTION
We fix integration test flakiness by waiting until the IPFS network is ready.