### PR TITLE
Change Generic FromToRad for single constructor datatypes

### DIFF
--- a/src/Radicle/Internal/Core.hs
+++ b/src/Radicle/Internal/Core.hs
@@ -788,21 +788,32 @@ evenArgs name = \case
 -- * Generic encoding/decoding of Radicle values.
 
 toRadG :: forall a t. (HasEot a, ToRadG t (Eot a)) => a -> Annotated t ValueF
-toRadG x = toRadConss (constructors (datatype (Proxy :: Proxy a))) (toEot x)
+toRadG x = toRadConss (case conss of {[_] -> SingleCons; _ -> NonSingleCons})
+                      conss
+                      (toEot x)
+  where
+    conss = constructors (datatype (Proxy :: Proxy a))
+
+data ConstructorMultiplicity = SingleCons | NonSingleCons
 
 class ToRadG t a where
-  toRadConss :: [Constructor] -> a -> Annotated t ValueF
+  toRadConss :: ConstructorMultiplicity -> [Constructor] -> a -> Annotated t ValueF
+
+consArgs :: (CPA t , ToRadFields t a) => Fields -> a -> [Annotated t ValueF]
+consArgs fieldMeta fields =
+  case fieldMeta of
+    Selectors names ->
+      [Dict . Map.fromList $ zip (Keyword . Ident . toS <$> names) (toRadFields fields)]
+    NoSelectors _ -> toRadFields fields
+    NoFields -> []
 
 instance (CPA t, ToRadFields t a, ToRadG t b) => ToRadG t (Either a b) where
-  toRadConss (Constructor name fieldMeta : _) (Left fields) =
-    case fieldMeta of
-      Selectors names ->
-        radCons (toS name) . pure . Dict . Map.fromList $
-          zip (Keyword . Ident . toS <$> names) (toRadFields fields)
-      NoSelectors _ -> radCons (toS name) (toRadFields fields)
-      NoFields -> radCons (toS name) []
-  toRadConss (_ : r) (Right next) = toRadConss r next
-  toRadConss [] _ = panic "impossible"
+  toRadConss SingleCons [Constructor name fieldMeta] (Left fields) = case consArgs fieldMeta fields of
+    [a] -> a
+    as  -> radCons (toS name) as
+  toRadConss NonSingleCons (Constructor name fieldMeta : _) (Left fields) = radCons (toS name) $ consArgs fieldMeta fields
+  toRadConss NonSingleCons (_ : r) (Right next) = toRadConss NonSingleCons r next
+  toRadConss _ _ _ = panic "impossible"
 
 radCons :: CPA t => Prelude.String -> [Annotated t ValueF] -> Annotated t ValueF
 radCons name args = case args of
@@ -812,7 +823,7 @@ radCons name args = case args of
     consKw = Keyword . Ident . Identifier.kebabCons $ name
 
 instance ToRadG t Void where
-  toRadConss _ = absurd
+  toRadConss _ _ = absurd
 
 class ToRadFields t a where
   toRadFields :: CPA t => a -> [Annotated t ValueF]
@@ -824,10 +835,13 @@ instance ToRadFields t () where
   toRadFields () = []
 
 fromRadG :: forall a t. (CPA t, HasEot a, FromRadG t (Eot a)) => Annotated t ValueF -> Either Text a
-fromRadG v = do
-  (name, args) <- isRadCons v ?? gDecodeErr "expecting constructor"
-  fromEot <$> fromRadConss (constructors (datatype (Proxy :: Proxy a))) name args
-
+fromRadG v = case isRadCons v of
+    Nothing -> case conss of
+      [Constructor name _] -> fromEot <$> fromRadConss conss (Identifier.kebabCons (toS name)) [v]
+      _ -> Left $ gDecodeErr "expecting constructor: Haskell type is not single-constructor"
+    Just (name, args) -> fromEot <$> fromRadConss conss name args
+  where
+    conss = constructors (datatype (Proxy :: Proxy a))
 class FromRadG t a where
   fromRadConss :: [Constructor] -> Text -> [Annotated t ValueF] -> Either Text a
 

--- a/test/spec/Radicle/Internal/Foo.hs
+++ b/test/spec/Radicle/Internal/Foo.hs
@@ -2,7 +2,7 @@
 
 -- | The purpose of the 'Foo' datatype is to check the instances of
 -- 'FromRad' and 'ToRad' derived via generics.
-module Radicle.Internal.Foo (Foo) where
+module Radicle.Internal.Foo (Foo, Bar(..), Baz(..)) where
 
 import           Protolude
 
@@ -28,3 +28,21 @@ instance Arbitrary Foo where
     , FooC <$> arbitrary <*> arbitrary
     , pure FooD
     ]
+
+data Bar =
+  Bar { bar1 :: Text
+      , bar2 :: Scientific
+      } deriving (Eq, Show, Generic)
+
+instance FromRad t Bar
+instance ToRad t Bar
+instance Arbitrary Bar where
+  arbitrary = Bar <$> arbitrary <*> arbitrary
+
+newtype Baz = Baz Text
+  deriving (Eq, Show, Generic)
+
+instance FromRad t Baz
+instance ToRad t Baz
+instance Arbitrary Baz where
+  arbitrary = Baz <$> arbitrary

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -23,7 +23,7 @@ import           Radicle
 import qualified Radicle.Internal.Annotation as Ann
 import           Radicle.Internal.Arbitrary ()
 import           Radicle.Internal.Core (asValue, noStack)
-import           Radicle.Internal.Foo (Foo)
+import           Radicle.Internal.Foo (Bar(..), Baz(..), Foo)
 import           Radicle.Internal.TestCapabilities
 import           Radicle.TH
 
@@ -787,6 +787,22 @@ test_from_to_radicle =
         [ testForType (Proxy :: Proxy [Text]) ]
     , testGroup "Generic a => a"
         [ testForType (Proxy :: Proxy Foo) ]
+    , testGroup "Single constructor with selectors"
+        [ testForType (Proxy :: Proxy Bar) ]
+    , testGroup "Single constructor with no selectors"
+        [ testForType (Proxy :: Proxy Baz) ]
+    , testGroup "Constructors optional for single constructor datatypes"
+        [ let v = Vec $ fromList [ kw "bar"
+                                 , Dict $ fromList [ (kw "bar1", String "hello")
+                                                   , (kw "bar2", int 42)
+                                                   ]
+                                 ]
+              x = Bar{ bar1 = "hello", bar2 = 42 }
+          in testCase "works with selectors" $ fromRad v @?= Right x
+        , let v = Vec $ fromList [ kw "baz" , String "hello" ]
+              x = Baz "hello"
+          in testCase "works with no selectors" $ fromRad v @?= Right x
+        ]
 
     , testGroup "StdStream"
         [ kw "inherit" ~~ Inherit


### PR DESCRIPTION
For single-constructor Haskell data types:
- `toRad` will skip the constructor,
- `fromRad` will optionally parse the constructor.

Note that while this change is backwards compatible, it is not forwards compatible: the public daemon will need to be updated before it can accept expressions created with this version.