### PR TITLE
Add content type for easy-to-consume JSON

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -447,10 +447,11 @@ right now, formatted according to ISO 8601.
 
 Returns a JSON formatted string representing the input value. Numbers
 are only converted if they have a finite decimal expansion. Strings and
-booleans are converted to their JSON counterparts. Keywords are
-converted to JSON strings (dropping the initial ':'). Lists and vectors
-are converted to JSON arrays. Dicts are converted to JSON objects as
-long as all the keys are either strings or keywords.
+booleans are converted to their JSON counterparts. Atoms and keywords
+are converted to JSON strings (dropping the initial ':' for keywords).
+Lists and vectors are converted to JSON arrays. Dicts are converted to
+JSON objects as long as all the keys are strings, atoms, keywords,
+booleans or numbers.
 
 ``uuid!``
 ~~~~~~~~~

--- a/package.yaml
+++ b/package.yaml
@@ -74,6 +74,7 @@ library:
   - unliftio
   - unordered-containers
   - uuid
+  - vector
 
 tests:
   spec:

--- a/src/Radicle/Daemon/HttpApi.hs
+++ b/src/Radicle/Daemon/HttpApi.hs
@@ -1,11 +1,18 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-# LANGUAGE QuantifiedConstraints #-}
+
 module Radicle.Daemon.HttpApi
-    ( QueryRequest(..)
-    , QueryResponse(..)
+    ( QueryRequestF(..)
+    , QueryRequest
+    , QueryResponseF(..)
+    , QueryResponse
     , machineQueryEndpoint
 
-    , SendRequest(..)
-    , SendResponse(..)
+    , SendRequestF(..)
+    , SendRequest
+    , SendResponseF(..)
+    , SendResponse
     , machineSendEndpoint
 
     , NewResponse(..)
@@ -20,6 +27,8 @@ module Radicle.Daemon.HttpApi
     ) where
 
 import           Protolude
+
+import           Prelude (String)
 
 import           Data.Aeson ((.:), (.=))
 import qualified Data.Aeson as A
@@ -36,6 +45,7 @@ import           Radicle.Internal.Core
 import           Radicle.Internal.Parse
 import           Radicle.Internal.Pretty
 
+-- | Content type for values encoded as Radicle expression.
 data RadicleData
 
 instance Accept RadicleData where
@@ -47,6 +57,32 @@ instance ToRad Ann.WithPos a => MimeRender RadicleData a where
 instance FromRad Ann.WithPos a => MimeUnrender RadicleData a where
   mimeUnrender _ = first toS . (fromRad <=< parse "[daemon]") . toS
 
+-- | Content type for values encoded *loosely* as JSON.
+data RadicleJSON
+
+instance Accept RadicleJSON where
+  contentType _ = "application" HttpMedia.// "radicle-json"
+
+instance (Traversable t, A.ToJSON (t A.Value)) => MimeRender RadicleJSON (t Value) where
+  mimeRender _ x =
+    let y_ = traverse maybeJson x
+    in case y_ of
+         Just y -> A.encode y
+         Nothing -> "{\"error\": \"Radicle value did not have a JSON representation.\"}"
+
+-- instance (A.ToJSON a) => MimeRender RadicleJSON a where
+--   mimeRender _ = A.encode
+
+instance (Traversable t, A.FromJSON (t A.Value)) => MimeUnrender RadicleJSON (t Value) where
+  mimeUnrender _ s = do
+      x :: t A.Value <- A.eitherDecode (toS s)
+      traverse loose x
+    where
+      loose :: A.Value -> Either String Value
+      loose js = case maybeFromJson js of
+        Just v  -> pure v
+        Nothing -> Left "Could not decode Radicle expression from JSON."
+
 instance FromHttpApiData MachineId where
     parseUrlPiece = Right . MachineId . toS
     parseQueryParam = parseUrlPiece
@@ -54,63 +90,71 @@ instance FromHttpApiData MachineId where
 instance ToHttpApiData MachineId where
     toUrlPiece (MachineId id) = id
 
-newtype QueryRequest = QueryRequest { expression :: Value }
-  deriving (Generic)
+newtype QueryRequestF a = QueryRequest { expression :: a }
+  deriving (Functor, Foldable, Traversable, Generic, A.ToJSON, A.FromJSON)
 
-instance FromRad Ann.WithPos QueryRequest
-instance ToRad Ann.WithPos QueryRequest
+type QueryRequest = QueryRequestF Value
 
-instance A.ToJSON QueryRequest where
+instance {-# OVERLAPPING #-} A.ToJSON QueryRequest where
     toJSON QueryRequest{..} = A.object
         [ "expression" .= valueToJson expression
         ]
-instance A.FromJSON QueryRequest where
+instance {-# OVERLAPPING #-} A.FromJSON QueryRequest where
     parseJSON = A.withObject "QueryRequest" $ \o -> do
         expression <- o .: "expression" >>= jsonToValue
         pure $ QueryRequest {..}
 
-newtype QueryResponse = QueryResponse { result :: Value }
-  deriving (Generic)
+instance FromRad Ann.WithPos QueryRequest
+instance ToRad Ann.WithPos QueryRequest
+
+newtype QueryResponseF v = QueryResponse { result :: v }
+  deriving (Functor, Foldable, Traversable, Generic, A.ToJSON, A.FromJSON)
+
+type QueryResponse = QueryResponseF Value
 
 instance FromRad Ann.WithPos QueryResponse
 instance ToRad Ann.WithPos QueryResponse
 
-instance A.ToJSON QueryResponse where
+instance {-# OVERLAPPING #-} A.ToJSON QueryResponse where
     toJSON QueryResponse{..} = A.object
         [ "result" .= valueToJson result
         ]
-instance A.FromJSON QueryResponse where
+instance {-# OVERLAPPING #-} A.FromJSON QueryResponse where
     parseJSON = A.withObject "QueryResponse" $ \o -> do
         result <- o .: "result" >>= jsonToValue
         pure $ QueryResponse {..}
 
-newtype SendRequest = SendRequest { expressions :: [Value] }
-  deriving (Generic)
+newtype SendRequestF v = SendRequest { expressions :: [v] }
+  deriving (Functor, Foldable, Traversable, Generic, A.ToJSON, A.FromJSON)
+
+type SendRequest = SendRequestF Value
 
 instance FromRad Ann.WithPos SendRequest
 instance ToRad Ann.WithPos SendRequest
 
-instance A.FromJSON SendRequest where
+instance {-# OVERLAPPING #-} A.FromJSON SendRequest where
     parseJSON = A.withObject "SendRequest" $ \o -> do
         expressions <- o .: "expressions" >>= traverse jsonToValue
         pure $ SendRequest {..}
-instance A.ToJSON SendRequest where
+instance {-# OVERLAPPING #-} A.ToJSON SendRequest where
     toJSON SendRequest{..} = A.object
         [ "expressions" .= map valueToJson expressions
         ]
 
-newtype SendResponse = SendResponse
-  { results :: [Value]
-  } deriving (Generic)
+newtype SendResponseF v = SendResponse
+  { results :: [v]
+  } deriving (Functor, Foldable, Traversable, Generic, A.ToJSON, A.FromJSON)
+
+type SendResponse = SendResponseF Value
 
 instance FromRad Ann.WithPos SendResponse
 instance ToRad Ann.WithPos SendResponse
 
-instance A.FromJSON SendResponse where
+instance {-# OVERLAPPING #-} A.FromJSON SendResponse where
     parseJSON = A.withObject "SendResponse" $ \o -> do
         results <- o .: "results" >>= traverse jsonToValue
         pure $ SendResponse {..}
-instance A.ToJSON SendResponse where
+instance {-# OVERLAPPING #-} A.ToJSON SendResponse where
     toJSON SendResponse{..} = A.object
         [ "results" .= map valueToJson results
         ]
@@ -130,7 +174,7 @@ instance A.FromJSON NewResponse
 
 -- * APIs
 
-type Formats = '[JSON, RadicleData]
+type Formats = '[JSON, RadicleData, RadicleJSON]
 
 type MachinesEndpoint t = "v0" :> "machines" :> t
 type MachineEndpoint t = MachinesEndpoint (Capture "machineId" MachineId :> t)
@@ -143,7 +187,7 @@ type MachineSendEndpoint = MachineEndpoint ("send" :> ReqBody Formats SendReques
 machineSendEndpoint :: Proxy MachineSendEndpoint
 machineSendEndpoint = Proxy
 
-type NewMachineEndpoint = MachinesEndpoint ("new" :> Post Formats NewResponse)
+type NewMachineEndpoint = MachinesEndpoint ("new" :> Post '[JSON, RadicleData] NewResponse)
 newMachineEndpoint :: Proxy NewMachineEndpoint
 newMachineEndpoint = Proxy
 

--- a/src/Radicle/Daemon/HttpApi.hs
+++ b/src/Radicle/Daemon/HttpApi.hs
@@ -64,8 +64,8 @@ instance Accept RadicleJSON where
 
 instance (Traversable t, A.ToJSON (t A.Value)) => MimeRender RadicleJSON (t Value) where
   mimeRender _ x = case traverse maybeJson x of
-    Just y -> A.encode y
-    Nothing -> "{\"error\": \"Radicle value did not have a JSON representation.\"}"
+    Right y -> A.encode y
+    Left e -> "{\"error\": \"Radicle value did not have a JSON representation: " <> toS e <> "\"}"
 
 instance (Functor t, A.FromJSON (t A.Value)) => MimeUnrender RadicleJSON (t Value) where
   mimeUnrender _ = fmap (fmap fromJson) . A.eitherDecode . toS

--- a/src/Radicle/Daemon/HttpApi.hs
+++ b/src/Radicle/Daemon/HttpApi.hs
@@ -66,14 +66,10 @@ data RadicleJSON
 instance Accept RadicleJSON where
   contentType _ = "application" HttpMedia.// "radicle-json"
 
-newtype NoRadicleJson = NoRadicleJson
-  { error :: Text
-  } deriving (Generic, A.ToJSON)
-
 instance (Traversable t, A.ToJSON (t A.Value)) => MimeRender RadicleJSON (t Value) where
   mimeRender _ x = case traverse maybeJson x of
     Right y -> A.encode y
-    Left e -> A.encode (NoRadicleJson ("Radicle value did not have a JSON representation: " <> e))
+    Left e -> A.encode $ A.object [("error", A.String ("Radicle value did not have a JSON representation: " <> e))]
 
 instance (Functor t, A.FromJSON (t A.Value)) => MimeUnrender RadicleJSON (t Value) where
   mimeUnrender _ = fmap (fmap fromJson) . A.eitherDecode . toS

--- a/src/Radicle/Daemon/Ipfs.hs
+++ b/src/Radicle/Daemon/Ipfs.hs
@@ -34,19 +34,11 @@ import           System.Timeout
 import           UnliftIO.Async
 
 import           Radicle.Internal.Core
+import           Radicle.Internal.Json
 import           Radicle.Internal.Parse
 import           Radicle.Internal.Pretty
 import qualified Radicle.Internal.UUID as UUID
 import qualified Radicle.Ipfs as Ipfs
-
-jsonToValue :: Aeson.Value -> Aeson.Parser Value
-jsonToValue = Aeson.withText "Value" $ \t -> do
-    case parse "[daemon]" t of
-      Left err -> fail $ "failed to parse Radicle expression: " <> show err
-      Right v  -> pure v
-
-valueToJson :: Value -> Aeson.Value
-valueToJson = Aeson.String . renderCompactPretty
 
 -- * Types
 

--- a/src/Radicle/Internal.hs
+++ b/src/Radicle/Internal.hs
@@ -12,6 +12,7 @@ import           Radicle.Internal.Effects as X
 import           Radicle.Internal.Eval as X
 import           Radicle.Internal.Identifier as X
 import           Radicle.Internal.Interpret as X
+import           Radicle.Internal.Json as X
 import           Radicle.Internal.Parse as X
 import           Radicle.Internal.Pretty as X
 import           Radicle.Internal.PrimFns as X

--- a/src/Radicle/Internal/Core.hs
+++ b/src/Radicle/Internal/Core.hs
@@ -95,7 +95,7 @@ noStack (Left (LangError _ err)) = Left err
 noStack (Right v)                = Right v
 
 typeToValue :: Type.Type -> Value
-typeToValue = Keyword . Ident . Identifier.kebabCons . drop 1 . show
+typeToValue = Keyword . Ident . Identifier.kebabCons . Type.typeString
 
 -- | Convert an error to a radicle value, and the label for it. Used for
 -- catching exceptions.

--- a/src/Radicle/Internal/Json.hs
+++ b/src/Radicle/Internal/Json.hs
@@ -3,11 +3,11 @@ module Radicle.Internal.Json where
 import           Protolude
 
 import           Control.Monad.Fail
-import qualified Data.Scientific as Sci
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as A
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
+import qualified Data.Scientific as Sci
 import qualified Data.Sequence as Seq
 import qualified Data.Vector as JsonVector
 

--- a/src/Radicle/Internal/Json.hs
+++ b/src/Radicle/Internal/Json.hs
@@ -1,0 +1,77 @@
+module Radicle.Internal.Json where
+
+import           Protolude
+
+import           Control.Monad.Fail
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
+import qualified Data.Vector as JsonVector
+
+import           Radicle.Internal.Core
+import           Radicle.Internal.Identifier
+import           Radicle.Internal.Number
+import           Radicle.Internal.Parse
+import           Radicle.Internal.Pretty
+
+-- | Parses JSON into a Value. It expects the value to be encoded as a radicle
+-- expression in a JSON string. Corresponds to the encoding given by
+-- 'valueToJson'.
+jsonToValue :: A.Value -> A.Parser Value
+jsonToValue = A.withText "Value" $ \t -> do
+    case parse "[daemon]" t of
+      Left err -> fail $ "failed to parse Radicle expression: " <> show err
+      Right v  -> pure v
+
+-- | Encodes a radicle value as JSON. The value is encoded a radicle expression
+-- formatted JSON string.
+valueToJson :: Value -> A.Value
+valueToJson = A.String . renderCompactPretty
+
+-- | Convert a radicle `Value` into an 'aeson' value, if possible.
+--
+-- >>> import Data.Aeson (encode)
+-- >>> encode $ maybeJson $ List [Number 3, String "hi"]
+-- "[3,\"hi\"]"
+--
+-- >>> import Data.Aeson (encode)
+-- >>> encode $ maybeJson $ Dict $ Map.fromList [(String "foo", String "bar")]
+-- "{\"foo\":\"bar\"}"
+--
+-- This fails for lambdas, since lambdas capture an entire environment (possibly
+-- recursively). It also fails for dictionaries with non-stringy (string or
+-- keyword) keys.
+--
+-- >>> import Data.Aeson (encode)
+-- >>> encode $ maybeJson $ Dict $ Map.fromList [(Number 3, String "bar")]
+-- "null"
+maybeJson :: Value -> Maybe A.Value
+maybeJson = \case
+    Number n -> A.Number <$> hush (isSci n)
+    String s -> pure $ A.String s
+    Keyword (Ident i) -> pure $ A.String i
+    Boolean b -> pure $ A.Bool b
+    List ls -> A.toJSON <$> traverse maybeJson ls
+    Vec xs -> A.toJSON <$> traverse maybeJson (toList xs)
+    Dict m -> do
+      let kvs = Map.toList m
+      ks <- traverse isStringy (fst <$> kvs)
+      vs <- traverse maybeJson (snd <$> kvs)
+      pure $ A.Object (HashMap.fromList (zip ks vs))
+    _ -> Nothing
+  where
+    isStringy (String s)          = pure s
+    isStringy (Keyword (Ident i)) = pure i
+    isStringy _                   = Nothing
+
+-- | Converts an `aeson` value to a radicle one.
+fromJson :: A.Value -> Value
+fromJson = \case
+  A.Number n -> Number (toRational n) -- TODO(james): think about untrusted sources.
+  A.String s -> String s
+  A.Bool b -> Boolean b
+  A.Array xs -> Vec $ Seq.fromList (JsonVector.toList (fromJson <$> xs))
+  A.Object kvs -> Dict $ Map.fromList $ bimap String fromJson <$> HashMap.toList kvs
+  A.Null -> Keyword (Ident "nothing")

--- a/src/Radicle/Internal/Json.hs
+++ b/src/Radicle/Internal/Json.hs
@@ -57,6 +57,7 @@ maybeJson = \case
     Number n -> A.Number <$> isSci n
     String s -> pure $ A.String s
     Keyword (Ident i) -> pure $ A.String i
+    Atom (Ident i) -> pure $ A.String i
     Boolean b -> pure $ A.Bool b
     List ls -> A.toJSON <$> traverse maybeJson ls
     Vec xs -> A.toJSON <$> traverse maybeJson (toList xs)

--- a/src/Radicle/Internal/Number.hs
+++ b/src/Radicle/Internal/Number.hs
@@ -27,4 +27,4 @@ toBoundedInteger r =
 isSci :: Rational -> Either Text Scientific.Scientific
 isSci r = case Scientific.fromRationalRepetendUnlimited r of
   (s, Nothing) -> pure s
-  _            -> Left "Does not have a non-repeating decimal expansion"
+  _            -> Left $ "The rational number " <> show r <> " does not have a non-repeating decimal expansion"

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -20,6 +20,7 @@ import           Radicle.Internal.Crypto
 import qualified Radicle.Internal.Doc as Doc
 import           Radicle.Internal.Eval
 import           Radicle.Internal.Identifier (Ident(..), unsafeToIdent)
+import qualified Radicle.Internal.Json as Json
 import qualified Radicle.Internal.Number as Num
 import           Radicle.Internal.Parse
 import           Radicle.Internal.Pretty
@@ -572,7 +573,7 @@ purePrimFns = fromList $ allDocs $
         \ Dicts are converted to JSON objects as long as all the keys are either\
         \ strings or keywords."
       , oneArg "to-json" $ \v -> String . toS . Aeson.encode <$>
-          maybeJson v ?? toLangError (OtherError "Could not serialise value to JSON")
+          Json.maybeJson v ?? toLangError (OtherError "Could not serialise value to JSON")
       )
     , ( "default-ecc-curve"
       , "Returns the default elliptic-curve used for generating cryptographic keys."

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -568,10 +568,10 @@ purePrimFns = fromList $ allDocs $
     , ( "to-json"
       , "Returns a JSON formatted string representing the input value. Numbers are only\
         \ converted if they have a finite decimal expansion. Strings and booleans are\
-        \ converted to their JSON counterparts. Keywords are converted to JSON strings\
-        \ (dropping the initial ':'). Lists and vectors are converted to JSON arrays.\
-        \ Dicts are converted to JSON objects as long as all the keys are either\
-        \ strings or keywords."
+        \ converted to their JSON counterparts. Atoms and keywords are converted to JSON strings\
+        \ (dropping the initial ':' for keywords). Lists and vectors are converted to JSON arrays.\
+        \ Dicts are converted to JSON objects as long as all the keys are strings, atoms,\
+        \ keywords, booleans or numbers."
       , oneArg "to-json" $ \v -> String . toS . Aeson.encode <$>
           case Json.maybeJson v of
             Left e -> throwErrorHere $ OtherError $ "Could not convert to JSON: " <> e

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -573,7 +573,9 @@ purePrimFns = fromList $ allDocs $
         \ Dicts are converted to JSON objects as long as all the keys are either\
         \ strings or keywords."
       , oneArg "to-json" $ \v -> String . toS . Aeson.encode <$>
-          Json.maybeJson v ?? toLangError (OtherError "Could not serialise value to JSON")
+          case Json.maybeJson v of
+            Left e -> throwErrorHere $ OtherError $ "Could not convert to JSON: " <> e
+            Right js -> pure js
       )
     , ( "default-ecc-curve"
       , "Returns the default elliptic-curve used for generating cryptographic keys."

--- a/src/Radicle/Internal/Type.hs
+++ b/src/Radicle/Internal/Type.hs
@@ -1,5 +1,6 @@
 module Radicle.Internal.Type where
 
+import           Prelude (String)
 import           Protolude hiding (Type)
 
 import           Codec.Serialise (Serialise)
@@ -24,3 +25,6 @@ data Type
   deriving (Eq, Show, Read, Generic)
 
 instance Serialise Type
+
+typeString :: Type -> String
+typeString = drop 1 . show

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -479,7 +479,9 @@ test_eval =
         runPureCode "(to-json {:foo #t \"bar\" #f})" @?= Right (String "{\"foo\":true,\"bar\":false}")
         runPureCode "(to-json (dict \"key\" (list 1 \"value\")))" @?= Right (String "{\"key\":[1,\"value\"]}")
         runPureCode "(to-json [3/2 #f])" @?= Right (String "[1.5,false]")
-        noStack (runPureCode "(to-json (dict 1 2))") @?= Left (OtherError "Could not serialise value to JSON")
+        runPureCode "(to-json {1 2})" @?= Right (String "{\"1\":2}")
+        runPureCode "(to-json {#t #f})" @?= Right (String "{\"true\":false}")
+        noStack (runPureCode "(to-json {[1] 2})") @?= Left (OtherError "Could not convert to JSON: Can not convert values of type Vec to a JSON key")
 
     , testCase "def-rec can define recursive functions" $ do
         let prog = [s|

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -481,7 +481,7 @@ test_eval =
         runPureCode "(to-json [3/2 #f])" @?= Right (String "[1.5,false]")
         runPureCode "(to-json {1 2})" @?= Right (String "{\"1\":2}")
         runPureCode "(to-json {#t #f})" @?= Right (String "{\"true\":false}")
-        noStack (runPureCode "(to-json {[1] 2})") @?= Left (OtherError "Could not convert to JSON: Can not convert values of type Vec to a JSON key")
+        noStack (runPureCode "(to-json {[1] 2})") @?= Left (OtherError "Could not convert to JSON: Cannot convert values of type Vec to a JSON key")
 
     , testCase "def-rec can define recursive functions" $ do
         let prog = [s|


### PR DESCRIPTION
Adds a `application/radicle-json` content-type so that consumers of the `query` endpoint may accept conveniently encoded JSON. E.g. for the `radicle-garden`:

`(list-patches)`:

```json
{
  "15": {
    "author-email": "haze",
    "state": "accepted",
    "created-at": "2019-03-13T16:00:51Z",
    "patch": "From 7c1002a7c13666a377b98241e87e699178ba0d67 Mon Sep 17 00:00:00 2001\nFrom: haze <isnt@haze.cool>\nDate: Wed, 13 Mar 2019 12:00:41 -0400\nSubject: [PATCH] Uprooting a galaxy\n\n---\n 2019-03-13_haze.txt | 8 ++++++++\n 1 file changed, 8 insertions(+)\n create mode 100644 2019-03-13_haze.txt\n\ndiff --git a/2019-03-13_haze.txt b/2019-03-13_haze.txt\nnew file mode 100644\nindex 0000000..80e8c14\n--- /dev/null\n+++ b/2019-03-13_haze.txt\n@@ -0,0 +1,8 @@\n+┌──────────────────┐\n+│       \\Λ/        │\n+│     ──▕ ▏──      │\n+│       /V\\        │\n+│                  │\n+│  T A C H Y O N   │\n+│ S O F T W A R E  │\n+└──────────────────┘\n\\ No newline at end of file\n-- \n2.17.2 (Apple Git-113)\n",
    "author-name": "haze",
    "author": [
      "public-key",
      {
        "public_curve": [
          "curve-fP",
          [
            "curve-prime",
            115792089237316195423570985008687907853269984665640564039457584007908834671663,
            [
              "curve-common",
              {
                "ecc_g": [
                  "point",
                  55066263022277343669578718895168534326250603453777594175500187360389116729240,
                  32670510020758816978083085130507043184471273380659243275938904335757337482424
                ],
                "ecc_a": 0,
                "ecc_n": 115792089237316195423570985008687907852837564279074904382605163141518161494337,
                "ecc_h": 1,
                "ecc_b": 7
              }
            ]
          ]
        ],
        "public_q": [
          "point",
          84104661149731357559625146477383645349462680667189717717948604614340334257896,
          28879832228416370287593549504197030105718169503737631177310776616050059709102
        ]
      }
    ],
    "short-hash": "7c1002a",
    "comments": [],
    "title": "Uprooting a galaxy",
    "number": 15,
    "description": "",
    "modified-at": "2019-03-13T16:29:55Z"
  },
  "more": "..."
}
```