### PR TITLE
Add missing line break in project init prompt

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -122,7 +122,7 @@
                'url ["3. Remote origin of existing current git repository:"
                      (string-append "   " url)])
          ])))
-    (match (prompt! question)
+    (match (prompt! (string-append question "\n"))
            "1" (init-git-ipfs-repo cid-of-empty-repo)
            "2" (do
                  (def remote-url (prompt! "Please input the remote git repo URL: "))


### PR DESCRIPTION
Adds a line break after the prompt asking for the repo kind to set up a new project.