### PR TITLE
Cleanup help texts and small fix

### DIFF
--- a/bin/rad-issue
+++ b/bin/rad-issue
@@ -35,7 +35,7 @@
         rad issue new
         rad issue [show | close | mark-read | mark-unread] <issue-number>
         rad issue comment <issue-number> <comment>
-        rad all-read
+        rad issue all-read
         rad issue help
 
      list         - Lists all issues

--- a/bin/rad-project
+++ b/bin/rad-project
@@ -22,12 +22,12 @@
   :unqualified)
 
 (def help
-  "rad-project - Radicle project CLI
+  "rad project - Radicle project CLI
 
    Usage:
-        rad-project init
-        rad-project show-id
-        rad-project checkout <PROJECT-ID>
+        rad project init
+        rad project show-id
+        rad project checkout <PROJECT-ID>
 
      init         - Initialize a new project
      show-id      - Show the project id
@@ -131,7 +131,7 @@
                  remote-url)
            "3" (if (eq? current-remote "")
                  (do (put-str! "No current remote origin set; please select 1 or 2.")
-                     (exit! !))
+                     (exit! 1))
                  current-remote)
            _   (do (put-str! "You must select either 1 or 2.")
                    (exit! 1)))))

--- a/bin/rad-replicate
+++ b/bin/rad-replicate
@@ -11,13 +11,13 @@
 
 (def help
   (string-append
-    "rad-replicate - Replicate radicle projects.
+    "rad replicate - Replicate radicle projects.
 
     This can be used to make your machines more available (e.g., readable when
     you are offline, or writable and readable if you are behind a firewall).
 
      Usage:
-          rad-replicate [URL]
+          rad replicate [URL]
 
     If not provided, the URL defaults to " default-url))
 


### PR DESCRIPTION
- removes the dashes in the commands of the help texts of `rad project` and `rad replicate` 
- adds missing `issue` to `rad issue` help text 
- fixes a typo in `setup-repo!` in `rad project`