### PR TITLE
Issue 325 - replace shebang with empty string to preserve source line count

### DIFF
--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -372,5 +372,5 @@ replPrimFns sysArgs = fromList $ allDocs $
 -- lines.
 ignoreShebang :: Text -> Text
 ignoreShebang src = case T.lines src of
-    f:rest -> T.unlines $ if "#!" `T.isPrefixOf` f then rest else f:rest
+    f:rest -> T.unlines $ if "#!" `T.isPrefixOf` f then mempty:rest else f:rest
     _      -> src


### PR DESCRIPTION
This fixes the issues described on #325 . When a radicle file begins with a shebang line, the line number in an error message is off by one. The line count changes because the shebang line is removed. This replaces the shebang line with an empty line, preserving the line count.