### PR TITLE
Issue 29 - support lambda definition with an atom representing an arguments vector

### DIFF
--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -110,9 +110,15 @@ valueDoc name docString value = case value of
         <> parseMarkdownBlocks docString
   where
     lambdaDoc args =
-        let callExample = "(" <> T.intercalate " " (name : map fromIdent args) <> ")"
-        in [ Header 3 nullAttr [Code nullAttr (toS callExample) ] ]
-           <> parseMarkdownBlocks docString
+      let callExample = "(" <> T.intercalate " " (name : lambdaArgsDoc args) <> ")"
+      in [ Header 3 nullAttr [Code nullAttr (toS callExample) ] ]
+        <> parseMarkdownBlocks docString
+    lambdaArgsDoc args =
+      case args of
+        PosArgs argNames ->
+          map fromIdent argNames
+        VarArgs _ ->
+          pure "arg1 ..."
 
 -- | Generate documentation for primitive functions defined by 'replBindings'
 docForPrimFns :: Content -> [Block]

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -23,6 +23,7 @@ module Radicle
     --
     -- *** Value
     , ValueF(..)
+    , LambdaArgs(..)
     , type Value
     , Type(..)
     , pattern Atom

--- a/src/Radicle/Internal/Pretty.hs
+++ b/src/Radicle/Internal/Pretty.hs
@@ -74,21 +74,17 @@ instance forall t. (Copointed t, Ann.Annotation t) => PrettyV (Ann.Annotated t V
       where
         -- We print string literals escaped just like Haskell does.
         escapeStr = T.init . T.tail . show
-        prettyLambda (PosArgs ids) vals =
-          let args :: Ann.Annotated t ValueF = Vec $ Seq.fromList (Atom <$> ids)
+        prettyLambda lArgs vals =
+          let args :: Ann.Annotated t ValueF = case lArgs of
+                PosArgs ids ->
+                  Vec $ Seq.fromList (Atom <$> ids)
+                VarArgs id ->
+                  Atom id
           in parens $
                annotate TAtom "fn" <+>
                align (sep [ prettyV args
                           , sep $ prettyV <$> toList vals
                           ])
-        prettyLambda (VarArgs id) vals =
-          let varArg :: Ann.Annotated t ValueF = Atom id
-          in parens $
-               annotate TAtom "fn" <+>
-               align (sep [ prettyV varArg
-                          , sep $ prettyV <$> toList vals
-                          ])
-
 
 instance Pretty Ann.SrcPos where
     pretty (Ann.SrcPos pos)        = pretty (sourcePosPretty pos)

--- a/src/Radicle/Internal/Pretty.hs
+++ b/src/Radicle/Internal/Pretty.hs
@@ -74,13 +74,21 @@ instance forall t. (Copointed t, Ann.Annotation t) => PrettyV (Ann.Annotated t V
       where
         -- We print string literals escaped just like Haskell does.
         escapeStr = T.init . T.tail . show
-        prettyLambda ids vals =
+        prettyLambda (PosArgs ids) vals =
           let args :: Ann.Annotated t ValueF = Vec $ Seq.fromList (Atom <$> ids)
           in parens $
                annotate TAtom "fn" <+>
                align (sep [ prettyV args
                           , sep $ prettyV <$> toList vals
                           ])
+        prettyLambda (VarArgs id) vals =
+          let varArg :: Ann.Annotated t ValueF = Atom id
+          in parens $
+               annotate TAtom "fn" <+>
+               align (sep [ prettyV varArg
+                          , sep $ prettyV <$> toList vals
+                          ])
+
 
 instance Pretty Ann.SrcPos where
     pretty (Ann.SrcPos pos)        = pretty (sourcePosPretty pos)

--- a/test/spec/Radicle/Internal/Arbitrary.hs
+++ b/test/spec/Radicle/Internal/Arbitrary.hs
@@ -32,7 +32,7 @@ instance Arbitrary Value where
                 , (3, Number <$> arbitrary)
                 , (1, List <$> sizedList)
                 , (6, PrimFn <$> elements (Map.keys $ getPrimFns prims))
-                , (1, Lambda <$> PosArgs <$> sizedList
+                , (1, Lambda <$> lambdaArgs
                              <*> scale (`div` 3) arbitrary
                              <*> scale (`div` 3) arbitrary)
                 ]
@@ -46,6 +46,7 @@ instance Arbitrary Value where
         prims = purePrimFns
         isPrimop x = x `elem` Map.keys (getPrimFns prims)
         isNum x = isJust (readMaybe (toS $ fromIdent x) :: Maybe Scientific)
+        lambdaArgs = oneof [ PosArgs <$> sizedList, VarArgs <$> arbitrary ]
 
 instance Arbitrary UntaggedValue where
     arbitrary = untag <$> (arbitrary :: Gen Value)

--- a/test/spec/Radicle/Internal/Arbitrary.hs
+++ b/test/spec/Radicle/Internal/Arbitrary.hs
@@ -32,7 +32,7 @@ instance Arbitrary Value where
                 , (3, Number <$> arbitrary)
                 , (1, List <$> sizedList)
                 , (6, PrimFn <$> elements (Map.keys $ getPrimFns prims))
-                , (1, Lambda <$> sizedList
+                , (1, Lambda <$> PosArgs <$> sizedList
                              <*> scale (`div` 3) arbitrary
                              <*> scale (`div` 3) arbitrary)
                 ]

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -219,8 +219,12 @@ test_eval =
                 <> "\nGot:\n" <> prettyEither res1
         counterexample (toS info) $ res1 == res2
 
-    , testCase "lambdas work" $ do
+    , testCase "lambdas with explicit arguments work" $ do
         let prog = [s|((fn [x] x) #t)|]
+        prog `succeedsWith` Boolean True
+
+    , testCase "lambdas with a vector of arguments work" $ do
+        let prog = [s|((fn x (first x)) #t)|]
         prog `succeedsWith` Boolean True
 
     , testCase "lambda does not have access to future definitions (hyper static)" $ do


### PR DESCRIPTION
Is there still interest in supporting a lambda arguments list as described on [issue 29](https://github.com/radicle-dev/radicle/issues/29)? If there is, what do you think of this approach? 

A few notes:

- This binds a vector to the atom instead of a list to maintain consistency with the current lambda syntax
- The generated call example is `(foo arg1 ...)`
- I haven't added tests yet