### PR TITLE
Issue 231 - support multiple expressions in a test :setup step

### DIFF
--- a/rad/prelude/test.rad
+++ b/rad/prelude/test.rad
@@ -63,14 +63,16 @@
   ))
 
 (def extract-setup
-  "Extracts the a setup step from the test steps. Returns a `[setup steps]` tuple."
+  "Extracts the setup step from the test steps. Returns a `[setup steps]` tuple."
   (fn [steps]
-    (match steps
-      (/cons [:setup 'setup] 'steps)
-        [setup steps]
-      'steps
-        [:nothing steps])
-  ))
+    (def first-step (first steps))
+    (def first-lhs (first first-step))
+    (match first-lhs
+      :setup
+        [(rest first-step) (rest steps)]
+      'otherwise
+        [:nothing steps]
+  )))
 
 (def parse-doc-test
   "Parse a doc test definition `test-def` and return a simple test. A


### PR DESCRIPTION
Based on #231 , this adds support for multiple expressions in a test :setup step. Because of the way the :setup step is matched, a :setup step with more than 1 expression is treated as a regular test step. Then the test fails later with this error:

```
Exception parse-test-step "Expected and actual not separate by ==>"
  src/Radicle/Internal/PrimFns.hs:166:32 throwErrorHere
  prelude/test.rad:62:74
```

Supporting multiple expressions resolves this problem and is perhaps a little nicer than nesting multiple expression inside a `do` expression. If one expression is preferred, then I think an exception should be thrown in `extract-setup`. 