### PR TITLE
Move writeMachineConfig outside of modifyMachine'

### DIFF
--- a/exe/Daemon.hs
+++ b/exe/Daemon.hs
@@ -244,11 +244,10 @@ send id (Api.SendRequest expressions) = do
 -- If the machine is not yet loaded into memory we fetch its inputs, load it
 -- into memory and start following its changes.
 ensureMachineLoaded :: MachineId -> Daemon Machine
-ensureMachineLoaded id =
-    modifyMachine' id $ \case
+ensureMachineLoaded id = do
+    m <- modifyMachine' id $ \case
         Nothing -> do
             m <- initAsReader id
-            writeMachineConfig
             pure (Just (Cached m), m)
         Just (UninitialisedReader _) -> do
             m <- initAsReader id
@@ -256,6 +255,8 @@ ensureMachineLoaded id =
         Just (Cached m) -> do
             m' <- pullInputs m
             pure (Just (Cached m'), m')
+    writeMachineConfig
+    pure m
 
 -- | Creates a IPFS pusbsub subscription for the given machine. This
 -- wraps 'initSubscription' and logs all message parsing errors.

--- a/src/Radicle/Daemon/Ipfs.hs
+++ b/src/Radicle/Daemon/Ipfs.hs
@@ -276,7 +276,7 @@ removeHandler ts u =
 
 -- | Block while waiting for a matching message.
 -- If no matching message arrives within the given timeout (in
--- milliseconds) then @Nothing@ is retuend.
+-- milliseconds) then @Nothing@ is returned.
 subscribeOne :: TopicSubscription -> Int64 -> (Message -> Maybe a) -> IO (Maybe a)
 subscribeOne subscription t matchMessage = do
     timeout (fromIntegral t * 1000) $ do

--- a/src/Radicle/Internal/ConcurrentMap.hs
+++ b/src/Radicle/Internal/ConcurrentMap.hs
@@ -31,7 +31,7 @@ lookup k (CMap m_) = withMVar m_ $ \m -> do
      Nothing -> pure Nothing
      Just v_ -> readMVar v_
 
--- | Non-atmoically read the contents of a 'CMap'. Provides a
+-- | Non-atomically read the contents of a 'CMap'. Provides a
 -- consistent shapshot of which keys were present at some
 -- time. However, the values might be snapshotted at different times.
 nonAtomicRead :: CMap k v -> IO (Map k v)


### PR DESCRIPTION
This fixes `rad project checkout` for new projects (ie projects that are not in the machines.json file yet).