### PR TITLE
nix: pin nixpkgs at 18.09

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,8 @@
-{ pkgs ? import <nixpkgs> {}
+{ pkgs ? import (fetchGit {
+    url = https://github.com/nixos/nixpkgs.git;
+    ref = "release-18.09";
+    rev = "34a637ca9235f44fc377a881c1e48e1e6bcf84f7";
+  }) {}
 , compiler ? "ghc863"
 , doc ? true
 , extras ? true


### PR DESCRIPTION
For reproducibility, and because the version of GHC in shell.nix isn't
available in latest nixpkgs.