### PR TITLE
fix: Version numbers for deb packages

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -220,9 +220,9 @@ steps:
     - |
       set -euxo pipefail
       if [[ "$TAG_NAME" == v* ]]; then
-        VERSION="$TAG_NAME" TARGET=debian ./packaging/build-package.sh
+        VERSION=${TAG_NAME/#"v"} TARGET=debian ./packaging/build-package.sh
         cp  \
-          "packaging/out/radicle_${TAG_NAME}_amd64.deb" \
+          "packaging/out/radicle_v${TAG_NAME}_amd64.deb" \
           "packaging/out/radicle_latest_amd64.deb"
         ./packaging/upload.sh
       fi


### PR DESCRIPTION
We had e.g. v0.0.3 instead of 0.0.3.

Fixes issue #627.