### PR TITLE
Allow unsigned request

### DIFF
--- a/rad/monadic/issue-remote.rad
+++ b/rad/monadic/issue-remote.rad
@@ -183,10 +183,8 @@
       x
       (insert :modified-at (lookup :created-at x) x))))
 
-(def create-issue
-  "Create an issue from a dict, checking that it is valid and storing it in `issues`."
+(def add-issue
   (fn [i]
-    (validator/input i)
     (def fixed
       (insert :comments
               (map fix-modified-at (lookup :comments i))
@@ -201,6 +199,18 @@
     (set-issues (@ n) i_)
     (noncer [:use (lookup :nonce i)])
     n))
+
+(def create-issue
+  "Create an issue from a dict, checking that it is valid and storing it in `issues`."
+  (fn [i]
+    (validator/input i)
+    (add-issue i)))
+
+(def anonymous-create-issue
+  "Anonymously create an issue from a dict, checking that it is valid and storing it in `issues`."
+  (fn [i]
+    ((validator/keys input-keys) i)
+    (add-issue i)))
 
 (def add-comment
   "Add a comment to an issue."
@@ -244,12 +254,13 @@
 
 (def commands
   "The set of allowed machine commands."
-  {'create-issue create-issue
-   'edit-issue   edit-issue
-   'add-comment  add-comment
-   'edit-comment edit-comment
-   'list-issues  list-issues
-   'add-admin    (add-admin auth)})
+  {'create-issue            create-issue
+   'anonymous-create-issue  anonymous-create-issue
+   'edit-issue              edit-issue
+   'add-comment             add-comment
+   'edit-comment            edit-comment
+   'list-issues             list-issues
+   'add-admin               (add-admin auth)})
 
 
 (def eval (make-updatable-eval commands (auth [:allowed :admin])))

--- a/rad/prelude/validation.rad
+++ b/rad/prelude/validation.rad
@@ -233,18 +233,16 @@
   "Checks that a value is a dict with `:signature` and `:author` keys, and that
   the signature is valid for the rest of the dict for that author. The rest of
   the dict is turned into a string according to `show`."
-  (or
-    [ (keys {:author (= :browser)})
-      (and
-        [(keys
-         {:author (pred "valid public key" public-key?)})
-        (pred
-         "Valid signature"
-         (fn [d]
-           (verify-signature
-            (lookup :author d)
-            (lookup :signature d)
-            (show (delete-many [:author :signature] d)))))])]))
+  (and
+   [(keys
+     {:author (pred "valid public key" public-key?)})
+    (pred
+     "Valid signature"
+     (fn [d]
+       (verify-signature
+        (lookup :author d)
+        (lookup :signature d)
+        (show (delete-many [:author :signature] d)))))]))
 
 (:test "signed"
   [:setup
@@ -260,15 +258,11 @@
                   :signature sig})
        (def full (<> payload seal))
        (def full_ (<> payload_ seal))
-       (def from-browser (<> payload_ {:author :browser}))
        (def ok
          (catch 'validation-failure (do (signed full) :ok) (fn [_] :not-ok)))
        )
-       (def ok-unsigned
-         (catch 'validation-failure (do (signed from-browser) :ok) (fn [_] :not-ok)))
    ]
   [ ok ==> :ok ]
-  [ ok-unsigned ==> :ok ]
 )
 
 (def timestamp

--- a/rad/prelude/validation.rad
+++ b/rad/prelude/validation.rad
@@ -233,16 +233,18 @@
   "Checks that a value is a dict with `:signature` and `:author` keys, and that
   the signature is valid for the rest of the dict for that author. The rest of
   the dict is turned into a string according to `show`."
-  (and
-   [(keys
-     {:author (pred "valid public key" public-key?)})
-    (pred
-     "Valid signature"
-     (fn [d]
-       (verify-signature
-        (lookup :author d)
-        (lookup :signature d)
-        (show (delete-many [:author :signature] d)))))]))
+  (or
+    [ (keys {:author (= :browser)})
+      (and
+        [(keys
+         {:author (pred "valid public key" public-key?)})
+        (pred
+         "Valid signature"
+         (fn [d]
+           (verify-signature
+            (lookup :author d)
+            (lookup :signature d)
+            (show (delete-many [:author :signature] d)))))])]))
 
 (:test "signed"
   [:setup
@@ -258,11 +260,15 @@
                   :signature sig})
        (def full (<> payload seal))
        (def full_ (<> payload_ seal))
+       (def from-browser (<> payload_ {:author :browser}))
        (def ok
          (catch 'validation-failure (do (signed full) :ok) (fn [_] :not-ok)))
        )
+       (def ok-unsigned
+         (catch 'validation-failure (do (signed from-browser) :ok) (fn [_] :not-ok)))
    ]
   [ ok ==> :ok ]
+  [ ok-unsigned ==> :ok ]
 )
 
 (def timestamp


### PR DESCRIPTION
This is a quick way of allowing unsigned requests. 
Setting up a new machine with the updated validation, I was able to send an unsigned request via jsradicle. The missing `:author` is just shown as `???`. If the request is limited to admins or a specific author, the validations fail as expected.

The current implementation has no "nice" validation failure message if there is no signature and the author is not `:browser`. The change automatically applies to all machines. It could be separated out to allow unsigned requests only in specific places.

Unsigned commands can be tested with `SendUnsignedCommand` from https://gist.github.com/MeBrei/1b998ac354b19ed7465903cb3df21e13