### PR TITLE
Remove reloads of error-messages module

### DIFF
--- a/rad/monadic/items.rad
+++ b/rad/monadic/items.rad
@@ -4,7 +4,6 @@
  '[summary pretty-item-view list-items pretty-state enrich-item
    verify-item-number]}
 
-(file-module! "prelude/error-messages.rad")
 (import prelude/error-messages :as 'error)
 
 (def summary

--- a/rad/prelude/cmd-parsing.rad
+++ b/rad/prelude/cmd-parsing.rad
@@ -10,8 +10,6 @@
 (import prelude/lens :unqualified)
 (import prelude/seq :unqualified)
 (import prelude/strings :unqualified)
-
-(file-module! "prelude/error-messages.rad")
 (import prelude/error-messages :as 'error)
 
 (def parse-failure-mode (ref {:stub #f}))

--- a/rad/prelude/key-management.rad
+++ b/rad/prelude/key-management.rad
@@ -8,8 +8,6 @@
 (import prelude/io-utils :as 'io)
 (import prelude/strings :as 'string)
 (import prelude/lens :unqualified)
-
-(file-module! "prelude/error-messages.rad")
 (import prelude/error-messages :as 'error)
 
 (def key-pair-mode (ref {:use-fake-key #f}))


### PR DESCRIPTION
error-message.rad is already loaded by prelude. This caused its
tests to run several times.