### PR TITLE
Issues frontend

### DIFF
--- a/rad/monadic/issue-remote.rad
+++ b/rad/monadic/issue-remote.rad
@@ -250,6 +250,10 @@
   "List existing issues."
   (fn [] (read-ref issues)))
 
+(def get-html
+  "The frontend."
+  (fn [] "QmQ1mvvp2kSNZwFQV2RAABdYFNEHYV3HXXEk64ZUGiKUX8"))
+
 ;; General logic
 
 (def commands
@@ -260,6 +264,7 @@
    'add-comment             add-comment
    'edit-comment            edit-comment
    'list-issues             list-issues
+   'get-html                get-html
    'add-admin               (add-admin auth)})
 
 

--- a/rad/monadic/issue-remote.rad
+++ b/rad/monadic/issue-remote.rad
@@ -254,10 +254,10 @@
   (fn [] (read-ref html)))
 
 (def set-html
-  "The frontend."
-  (fn []
-      (auth [:allowed :admin])
-      (read-ref html)))
+  "Change frontend. The new HTML should be an IPFS CID."
+  (fn [new-html]
+      ((validator/and [(auth [:allowed :admin]) validator/signed]) new-html)
+      (write-ref html new-html)))
 
 ;; These are intended for clients to run locally with eval-in-machine
 
@@ -277,6 +277,7 @@
    'edit-comment            edit-comment
    'list-issues             list-issues
    'get-html                get-html
+   'set-html                set-html
    'add-admin               (add-admin auth)})
 
 

--- a/rad/monadic/issue-remote.rad
+++ b/rad/monadic/issue-remote.rad
@@ -244,15 +244,27 @@
           (def c_ (strip-input c))
           (over-issues (... [(@ n) (@ :comments) (@nth i)]) (merge-new c_))))))
 
+
+;; HTML frontend
+
+(def html (ref "QmcENMqxFaYifTCGpHwureKnyEAEfgQXZ8fW35kn17uQPP"))
+
+(def get-html
+  "The frontend."
+  (fn [] (read-ref html)))
+
+(def set-html
+  "The frontend."
+  (fn []
+      (auth [:allowed :admin])
+      (read-ref html)))
+
 ;; These are intended for clients to run locally with eval-in-machine
 
 (def list-issues
   "List existing issues."
   (fn [] (read-ref issues)))
 
-(def get-html
-  "The frontend."
-  (fn [] "QmQ1mvvp2kSNZwFQV2RAABdYFNEHYV3HXXEk64ZUGiKUX8"))
 
 ;; General logic
 


### PR DESCRIPTION
This gives every issues machine a frontend at the URL `http://localhost:8909/v0/machines/<machineid>/frontend/index.html`. Some caveats:

- So far only reading works (even though the plumbing is there for creating issues). This is because we need @MeBrei's changes in `v2` for writing.
- The `machineid` in the URL is that of the issues machine, so sort of annoying to figure out. I think the right approach is to have another frontend for the project, which links to the issues, but that hasn't been implemented here.

The CID is that of the build of commit 14738f8 in https://github.com/radicle-dev/rad-issues-frontend/pull/3.