### PR TITLE
Remove `eval` export from `prelude/machine`

### DIFF
--- a/bin/rad-repl
+++ b/bin/rad-repl
@@ -1,6 +1,5 @@
 #!/usr/bin/env radicle
 (load! (find-module-file! "prelude.rad"))
-(import prelude/machine '[eval] :unqualified)
 
 (def help
   "Default help text."

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1443,11 +1443,6 @@ ones. This is intended for testing.
 
 Functions for simulating remote machines.
 
-``(eval expr state)``
-~~~~~~~~~~~~~~~~~~~~~
-
-Evaluation function that adds :test macro to register tests.
-
 ``(updatable-eval sub-eval)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/rad/prelude/machine.rad
+++ b/rad/prelude/machine.rad
@@ -1,6 +1,6 @@
 {:module 'prelude/machine
  :doc "Functions for simulating remote machines."
- :exports '[eval updatable-eval eval-fn-app send-prelude! new-machine!
+ :exports '[updatable-eval eval-fn-app send-prelude! new-machine!
             send-code! send! query! install-remote-machine-fake send-signed-command!
             catch-daemon!]}
 


### PR DESCRIPTION
- Because it doesn't even define an `eval`.
- And also remove this import in `repl.rad`.