### PR TITLE
feat: New show command

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -59,8 +59,8 @@ the the second argument (a list).
 
 Returns a string representing the argument value.
 
-``show-unbound``
-~~~~~~~~~~~~~~~~
+``show-unformatted``
+~~~~~~~~~~~~~~~~~~~~
 
 Returns a string representing the argument value. (No extra formatting)
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -59,6 +59,11 @@ the the second argument (a list).
 
 Returns a string representing the argument value.
 
+``show-unbound``
+~~~~~~~~~~~~~~~~
+
+Returns a string representing the argument value. (No extra formatting)
+
 ``throw``
 ~~~~~~~~~
 

--- a/rad/prelude/machine.rad
+++ b/rad/prelude/machine.rad
@@ -165,7 +165,7 @@
     (def ks (get-keys!))
     (def sig
       (gen-signature! (lookup :private-key ks)
-                      (show e_)))
+                      (show-unbound e_)))
     (<> e_
         {:author    (lookup :public-key ks)
          :signature sig})))

--- a/rad/prelude/machine.rad
+++ b/rad/prelude/machine.rad
@@ -165,7 +165,7 @@
     (def ks (get-keys!))
     (def sig
       (gen-signature! (lookup :private-key ks)
-                      (show-unbound e_)))
+                      (show-unformatted e_)))
     (<> e_
         {:author    (lookup :public-key ks)
          :signature sig})))

--- a/rad/prelude/validation.rad
+++ b/rad/prelude/validation.rad
@@ -243,7 +243,7 @@
        (verify-signature
         (lookup :author d)
         (lookup :signature d)
-        (show (delete-many [:author :signature] d)))))]))
+        (show-unbound (delete-many [:author :signature] d)))))]))
 
 (test "signed"
   [:setup
@@ -253,12 +253,10 @@
        (def payload
          {:nonce (uuid!)
           :some "data"})
-       (def payload_ (insert :some "datadata" payload))
-       (def sig  (gen-signature! sk (show payload)))
+       (def sig  (gen-signature! sk (show-unbound payload)))
        (def seal {:author    (lookup :public-key keys)
                   :signature sig})
        (def full (<> payload seal))
-       (def full_ (<> payload_ seal))
        (def ok
          (catch 'validation-failure (do (signed full) :ok) (fn [_] :not-ok)))
        )

--- a/rad/prelude/validation.rad
+++ b/rad/prelude/validation.rad
@@ -243,7 +243,7 @@
        (verify-signature
         (lookup :author d)
         (lookup :signature d)
-        (show-unbound (delete-many [:author :signature] d)))))]))
+        (show-unformatted (delete-many [:author :signature] d)))))]))
 
 (test "signed"
   [:setup
@@ -253,7 +253,7 @@
        (def payload
          {:nonce (uuid!)
           :some "data"})
-       (def sig  (gen-signature! sk (show-unbound payload)))
+       (def sig  (gen-signature! sk (show-unformatted payload)))
        (def seal {:author    (lookup :public-key keys)
                   :signature sig})
        (def full (<> payload seal))

--- a/reference-doc.yaml
+++ b/reference-doc.yaml
@@ -24,7 +24,7 @@ primFns:
 - eq?
 - apply
 - show
-- show-unbound
+- show-unformatted
 - throw
 - exit!
 - read-annotated

--- a/reference-doc.yaml
+++ b/reference-doc.yaml
@@ -24,6 +24,7 @@ primFns:
 - eq?
 - apply
 - show
+- show-unbound
 - throw
 - exit!
 - read-annotated

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -71,6 +71,7 @@ module Radicle
     -- * Pretty-printing
     , renderPretty
     , renderPrettyDef
+    , renderPrettyUnbounded
     , renderCompactPretty
     -- ** Re-exports
     , PageWidth(..)

--- a/src/Radicle/Internal/Pretty.hs
+++ b/src/Radicle/Internal/Pretty.hs
@@ -165,6 +165,15 @@ renderCompactPretty = renderStrict . layoutCompact . prettyV
 renderPretty :: PrettyV v => PageWidth -> v -> Text
 renderPretty pg = renderStrict . layoutSmart (LayoutOptions pg) . prettyV
 
+-- | 'renderPretty', but with unbounded width.
+--
+-- Example:
+--
+-- >>> renderPrettyUnbounded (asValue (List [String "hi", String "there"]))
+-- "(\"hi\" \"there\")"
+renderPrettyUnbounded :: PrettyV v => v -> Text
+renderPrettyUnbounded = renderPretty Unbounded
+
 -- | 'renderPretty', but with default layout options (80 chars, 1.0 ribbon)
 --
 -- Examples:

--- a/src/Radicle/Internal/Pretty.hs
+++ b/src/Radicle/Internal/Pretty.hs
@@ -67,7 +67,7 @@ instance forall t. (Copointed t, Ann.Annotation t) => PrettyV (Ann.Annotated t V
         Macro _ -> angles "macro"
         Dict mp -> braces . align $
             sep [ prettyV k <+> prettyV val
-                | (k, val) <- Map.toList mp ]
+                | (k, val) <- Map.toAscList mp ]
         Lambda ids vals _ -> prettyLambda ids vals
         LambdaRec _ ids vals _ -> prettyLambda ids vals
         VEnv _ -> angles "env"

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -568,9 +568,9 @@ purePrimFns = fromList $ allDocs $
     , ( "show"
       , "Returns a string representing the argument value."
       , oneArg "show" (pure . String . renderPrettyDef))
-    , ( "show-unbound"
+    , ( "show-unformatted"
       , "Returns a string representing the argument value. (No extra formatting)"
-      , oneArg "show-unbound" (pure . String . renderPrettyUnbounded))
+      , oneArg "show-unformatted" (pure . String . renderPrettyUnbounded))
     , ( "seq"
       , "Given a structure `s`, returns a sequence. Lists and vectors are returned\
         \ without modification while for dicts a vector of key-value-pairs is returned:\

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -570,7 +570,7 @@ purePrimFns = fromList $ allDocs $
       , oneArg "show" (pure . String . renderPrettyDef))
     , ( "show-unbound"
       , "Returns a string representing the argument value. (No extra formatting)"
-      , oneArg "show-com" (pure . String . renderPrettyUnbounded))
+      , oneArg "show-unbound" (pure . String . renderPrettyUnbounded))
     , ( "seq"
       , "Given a structure `s`, returns a sequence. Lists and vectors are returned\
         \ without modification while for dicts a vector of key-value-pairs is returned:\

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -568,6 +568,9 @@ purePrimFns = fromList $ allDocs $
     , ( "show"
       , "Returns a string representing the argument value."
       , oneArg "show" (pure . String . renderPrettyDef))
+    , ( "show-unbound"
+      , "Returns a string representing the argument value. (No extra formatting)"
+      , oneArg "show-com" (pure . String . renderPrettyUnbounded))
     , ( "seq"
       , "Given a structure `s`, returns a sequence. Lists and vectors are returned\
         \ without modification while for dicts a vector of key-value-pairs is returned:\

--- a/test/spec/Radicle/Internal/Arbitrary.hs
+++ b/test/spec/Radicle/Internal/Arbitrary.hs
@@ -64,15 +64,15 @@ gen textGen n | n == 0 = frequency $ first pred <$> freqs
     -- anything a user can write. So we don't generate dicts directly,
     -- instead requiring they go via the primop.
     freqs = [ (3, Atom <$> (arbitrary `suchThat` (\x -> not (isPrimop x || isNum x))))
-                , (3, String <$> textGen)
-                , (3, Boolean <$> arbitrary)
-                , (3, Number <$> arbitrary)
-                , (1, List <$> sizedList)
-                , (6, PrimFn <$> elements (Map.keys $ getPrimFns prims))
-                , (1, Lambda <$> lambdaArgs
-                             <*> scale (`div` 3) arbitrary
-                             <*> scale (`div` 3) arbitrary)
-                ]
+            , (3, String <$> textGen)
+            , (3, Boolean <$> arbitrary)
+            , (3, Number <$> arbitrary)
+            , (1, List <$> sizedList)
+            , (6, PrimFn <$> elements (Map.keys $ getPrimFns prims))
+            , (1, Lambda <$> lambdaArgs
+                         <*> scale (`div` 3) arbitrary
+                         <*> scale (`div` 3) arbitrary)
+            ]
 
     sizedList :: Arbitrary a => Gen [a]
     sizedList = sized $ \s -> do

--- a/test/spec/Radicle/Internal/Arbitrary.hs
+++ b/test/spec/Radicle/Internal/Arbitrary.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Radicle.Internal.Arbitrary where
+module Radicle.Internal.Arbitrary
+    ( NoSpaceValue(..)
+    ) where
 
 import           Protolude
 
@@ -20,13 +22,13 @@ instance Arbitrary r => Arbitrary (Env r) where
     arbitrary = Env <$> arbitrary
 
 instance Arbitrary Value where
-    arbitrary = sized (go arbitrary)
+    arbitrary = sized (gen arbitrary)
 
 newtype NoSpaceValue = NoSpaceValue Value
   deriving Show
 
 instance Arbitrary NoSpaceValue where
-    arbitrary = NoSpaceValue <$> sized (go textNoDoubleSpaces)
+    arbitrary = NoSpaceValue <$> sized (gen textNoDoubleSpaces)
       where textNoDoubleSpaces = arbitrary `suchThat` (not . T.isInfixOf "  ")
 
 instance Arbitrary UntaggedValue where
@@ -52,9 +54,9 @@ instance Arbitrary a => Arbitrary (Bindings a) where
 instance Arbitrary a => Arbitrary (Doc.Docd a) where
     arbitrary = Doc.Docd Nothing <$> arbitrary
 
-go :: Gen Text -> Int -> Gen Value
-go textGen n | n == 0 = frequency $ first pred <$> freqs
-             | otherwise = frequency freqs
+gen :: Gen Text -> Int -> Gen Value
+gen textGen n | n == 0 = frequency $ first pred <$> freqs
+              | otherwise = frequency freqs
   where
     -- There's no literal syntax for dicts, only the 'dict' primop. If we
     -- generated them directly, we would generate something that can only

--- a/test/spec/Radicle/Internal/Arbitrary.hs
+++ b/test/spec/Radicle/Internal/Arbitrary.hs
@@ -6,9 +6,9 @@ import           Protolude
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import           Data.Scientific (Scientific)
+import qualified Data.Text as T
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
-import qualified Data.Text as T
 
 import           Radicle
 import qualified Radicle.Internal.Doc as Doc

--- a/test/spec/Radicle/Internal/Arbitrary.hs
+++ b/test/spec/Radicle/Internal/Arbitrary.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Radicle.Internal.Arbitrary
-    ( NoSpaceValue(..)
+    ( NoDoubleSpacesValue(..)
     ) where
 
 import           Protolude
@@ -22,13 +22,13 @@ instance Arbitrary r => Arbitrary (Env r) where
     arbitrary = Env <$> arbitrary
 
 instance Arbitrary Value where
-    arbitrary = sized (gen arbitrary)
+    arbitrary = sized (valueGenerator arbitrary)
 
-newtype NoSpaceValue = NoSpaceValue Value
+newtype NoDoubleSpacesValue = NoDoubleSpacesValue Value
   deriving Show
 
-instance Arbitrary NoSpaceValue where
-    arbitrary = NoSpaceValue <$> sized (gen textNoDoubleSpaces)
+instance Arbitrary NoDoubleSpacesValue where
+    arbitrary = NoDoubleSpacesValue <$> sized (valueGenerator textNoDoubleSpaces)
       where textNoDoubleSpaces = arbitrary `suchThat` (not . T.isInfixOf "  ")
 
 instance Arbitrary UntaggedValue where
@@ -54,9 +54,9 @@ instance Arbitrary a => Arbitrary (Bindings a) where
 instance Arbitrary a => Arbitrary (Doc.Docd a) where
     arbitrary = Doc.Docd Nothing <$> arbitrary
 
-gen :: Gen Text -> Int -> Gen Value
-gen textGen n | n == 0 = frequency $ first pred <$> freqs
-              | otherwise = frequency freqs
+valueGenerator :: Gen Text -> Int -> Gen Value
+valueGenerator textGen n | n == 0 = frequency $ first pred <$> freqs
+                         | otherwise = frequency freqs
   where
     -- There's no literal syntax for dicts, only the 'dict' primop. If we
     -- generated them directly, we would generate something that can only

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -21,7 +21,7 @@ import qualified Text.Megaparsec.Pos as Par
 
 import           Radicle
 import qualified Radicle.Internal.Annotation as Ann
-import           Radicle.Internal.Arbitrary (NoSpaceValue(..))
+import           Radicle.Internal.Arbitrary
 import           Radicle.Internal.Core (asValue, noStack)
 import           Radicle.Internal.Foo (Bar(..), Baz(..), Foo)
 import           Radicle.Internal.TestCapabilities

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -21,7 +21,7 @@ import qualified Text.Megaparsec.Pos as Par
 
 import           Radicle
 import qualified Radicle.Internal.Annotation as Ann
-import           Radicle.Internal.Arbitrary ()
+import           Radicle.Internal.Arbitrary (NoSpaceValue(..))
 import           Radicle.Internal.Core (asValue, noStack)
 import           Radicle.Internal.Foo (Bar(..), Baz(..), Foo)
 import           Radicle.Internal.TestCapabilities
@@ -479,7 +479,7 @@ test_eval =
         runPureCode "(show-unbound {:bar \"bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar\" :foo \"foo foo foo foo foo\"})"
           @?= Right (String "{:bar \"bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar\" :foo \"foo foo foo foo foo\"}")
 
-    , testProperty "'show-unbounds does not add any whitespace characters'" $ \(val :: Value) -> do
+    , testProperty "'show-unbounds does not add any whitespace characters'" $ \(NoSpaceValue val :: NoSpaceValue) -> do
         let res = runPureCode $ toS [i|(show-unbound (quote #{renderPrettyUnbounded val}))|]
             info = "Expected to not include any double whitespace characters, line breaks or tabs:\n" <> toS (prettyEither res)
         counterexample info $ no_unallowed_whitespace (prettyEither res)
@@ -584,8 +584,8 @@ test_eval =
   where
     failsWith src err    = noStack (runPureCode src) @?= Left err
     succeedsWith src val = runPureCode src @?= Right val
-    no_tabs t = not $ T.isInfixOf "\t" t
-    no_line_breaks t = not $ T.isInfixOf "\n" t
+    no_tabs t = not $ T.any (== '\t') t
+    no_line_breaks t = not $ T.any (== '\n') t
     no_double_spaces t = not $ T.isInfixOf "  " t
     no_unallowed_whitespace t = no_double_spaces t && no_line_breaks t && no_tabs t
 

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -474,6 +474,16 @@ test_eval =
         runPureCode "(show (dict 'a 1))" @?= Right (String "{a 1}")
         runPureCode "(show (fn [x] x))" @?= Right (String "(fn [x] x)")
 
+    , testCase "'show-unbounds' works" $ do
+        runPureCode "(show-unbound {:b 2 :a 1})" @?= Right (String "{:a 1 :b 2}")
+        runPureCode "(show-unbound {:bar \"bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar\" :foo \"foo foo foo foo foo\"})"
+          @?= Right (String "{:bar \"bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar\" :foo \"foo foo foo foo foo\"}")
+
+    , testProperty "'show-unbounds does not add any whitespace characters'" $ \(val :: Value) -> do
+        let res = runPureCode $ toS [i|(show-unbound (quote #{renderPrettyUnbounded val}))|]
+            info = "Expected to not include any double whitespace characters, line breaks or tabs:\n" <> toS (prettyEither res)
+        counterexample info $ no_unallowed_whitespace (prettyEither res)
+
     , testCase "'read-anotated' works" $
         runPureCode "(read-annotated \"foo\" \"(:hello 42)\")" @?= Right (List [Keyword [ident|hello|], int 42])
 
@@ -574,6 +584,10 @@ test_eval =
   where
     failsWith src err    = noStack (runPureCode src) @?= Left err
     succeedsWith src val = runPureCode src @?= Right val
+    no_tabs t = not $ T.isInfixOf "\t" t
+    no_line_breaks t = not $ T.isInfixOf "\n" t
+    no_double_spaces t = not $ T.isInfixOf "  " t
+    no_unallowed_whitespace t = no_double_spaces t && no_line_breaks t && no_tabs t
 
 stackTraceLines :: [Ann.SrcPos] -> [Int]
 stackTraceLines = concatMap go


### PR DESCRIPTION
BREAKING CHANGE: This changes the structure of the message that is
signed before sending it to a machine. Machines set up before this
commit will not accept the new signatures.

`show-unbound` does not add formatting to the requests payload, to
make signing request consistently to work also in other languages.