### PR TITLE
nix: add dependency to git

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -12,5 +12,5 @@ haskell.lib.buildStackProject {
   inherit ghc;
   name = "radicle";
   LANG = "en_US.UTF-8";
-  buildInputs = [ zlib ipfs docker docker_compose ] ++ extras ;
+  buildInputs = [ git zlib ipfs docker docker_compose ] ++ extras ;
 }


### PR DESCRIPTION
Fixes this build error:

```
❯ stack --nix build
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading root
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading timestamp
Downloading snapshot
Downloading mirrors
Cannot update index (no local copy)
Downloading index
UpUpdated package index downloaded
Update complete
Populated index cache.
Cloning 057ba4a4bf9bb846a08b1208b0ed45af33a38082 from https://github.com/oscoin/ipfs.git
Unable to load cabal files for snapshot
Executable named git not found on path: ["/nix/store/zl47r98ihllg3694p4f26170v285g7ba-bash-interactive-4.4-p23/bin","/nix/store/3iy39r2v8417g7m4mvk98q0k3jbc25l1-ghc-8.6.4/bin","/nix/store/ghzg4kg0sjif58smj2lfm2bdvjwim85y-gcc-wrapper-7.4.0/bin","/nix/store/d4n93jn9fdq8fkmkm1q8f32lfagvibjk-gcc-7.4.0/bin","/nix/store/f5wl80zkrd3fc1jxsljmnpn7y02lz6v1-glibc-2.27-bin/bin","/nix/store/d9s1kq1bnwqgxwcvv4zrc36ysnxg8gv7-coreutils-8.30/bin","/nix/store/rbpyfy6413aqpik9aj6p3a2syd1mda68-binutils-wrapper-2.31.1/bin","/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin","/nix/store/f5wl80zkrd3fc1jxsljmnpn7y02lz6v1-glibc-2.27-bin/bin","/nix/store/d9s1kq1bnwqgxwcvv4zrc36ysnxg8gv7-coreutils-8.30/bin","/nix/store/zvxm5v15q3gpg49f482qxy06a28ry8hv-pkg-config-0.29.2/bin","/nix/store/lb9ggr3z2xfxzgkw067l5grvlggbyyzc-stack-1.9.3/bin","/nix/store/s7p0wfbdfbq307zgifhnh6w8sfjvy64y-patchelf-0.9/bin","/nix/store/k0y9nrym785l61pjw0lp0qk90v2nbpqs-ncurses-6.1-20190112/bin","/nix/store/wc9ybqv8k05kjfp72mp5hdz941bh7znv-ipfs-0.4.18-bin/bin","/nix/store/j0svnyxx45jk68fhslrssbsz0nmjqm41-docker-18.09.2/bin","/nix/store/5vxf7vcyn9jxiq86xydypd6py783h922-docker-compose-1.23.1/bin","/nix/store/0n8slcq8p5x31kc9hncabsqq9y3fpkzp-python3-3.7.3/bin","/nix/store/bn8xa5ww2p9pghjdgcix3w0alwlm00wh-python3.7-setuptools-40.8.0/bin","/nix/store/50p861jrj4a15717kpnlgx2vi1s1jflf-python3.7-chardet-3.0.4/bin","/nix/store/cnhqvg74gw590yys8shqm6vm3w4r1qqh-python3.7-websocket_client-0.54.0/bin","/nix/store/dr6mcznxvdpxj1a58fa4w29px4kv1i2j-python3.7-jsonschema-2.6.0/bin","/nix/store/d9s1kq1bnwqgxwcvv4zrc36ysnxg8gv7-coreutils-8.30/bin","/nix/store/krhqmaqal0gklh15rs2bwrqzz8mg9lrn-findutils-4.6.0/bin","/nix/store/pmzw4y4465zmq0dc8r4xbwyrqsaj4s70-diffutils-3.7/bin","/nix/store/x1khw8x0465xhkv6w31af75syyyxc65j-gnused-4.7/bin","/nix/store/wnjv27b3j6jfdl0968xpcymlc7chpqil-gnugrep-3.3/bin","/nix/store/vvwggp5mni64yavsfqmbwvm1mn692ssn-gawk-4.2.1/bin","/nix/store/wmxqm38g1y1y7sd7s9vg7an3klffaiyz-gnutar-1.31/bin","/nix/store/ix2q5vnynzfgsi4nqj8pmcbx2kf78wrm-gzip-1.10/bin","/nix/store/q6821d46lc5514rfh537c20f9ay2760l-bzip2-1.0.6.0.1-bin/bin","/nix/store/8n7v99ii7cg694pz0cfch422zvkdqfv4-gnumake-4.2.1/bin","/nix/store/cinw572b38aln37glr0zb8lxwrgaffl4-bash-4.4-p23/bin","/nix/store/jl17v3f872ax5wfi49b04mjzjz10rnra-patch-2.7.6/bin","/nix/store/zrazw25gy012ip7vcqddw6lcc393qvcg-xz-5.2.4-bin/bin"]
```