### PR TITLE
nix: remove redundant LANG attribute

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,6 +11,5 @@ with pkgs;
 haskell.lib.buildStackProject {
   inherit ghc;
   name = "radicle";
-  LANG = "en_US.UTF-8";
   buildInputs = [ git zlib ipfs docker docker_compose ] ++ extras ;
 }


### PR DESCRIPTION
It's already defined in `buildStackProject`, see [0].

[0]:
https://github.com/asymmetric/nixpkgs/tree/49dc8087a20e0d742d38be5f13333a03d171006a/pkgs/development/haskell-modules/generic-stack-builder.nix#L39