### PR TITLE
doc: fix stack invocation in nix-shell

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -26,4 +26,5 @@ And then, inside the shell:
 
 ``` sh
 stack build --system-ghc
+stack install --system-ghc :rad :radicle
 ```

--- a/nix/README.md
+++ b/nix/README.md
@@ -25,5 +25,5 @@ the flag `--arg pkgs "import <nixos-unstable> {}`)
 And then, inside the shell:
 
 ``` sh
-stack build --system-ghc --nix-packages zlib
+stack build --system-ghc
 ```

--- a/nix/README.md
+++ b/nix/README.md
@@ -25,6 +25,6 @@ the flag `--arg pkgs "import <nixos-unstable> {}`)
 And then, inside the shell:
 
 ``` sh
-stack build --system-ghc
-stack install --system-ghc :rad :radicle
+stack --nix build
+stack --nix install :rad :radicle
 ```


### PR DESCRIPTION
Passing `--nix-packages zlib` errored with "You cannot have packages and
a shell-file filled at the same time in your nix-shell configuration."

The PR also documents how to install inside a nix-shell.