### PR TITLE
CI: Set up Buildkite

### DIFF
--- a/.buildkite/build
+++ b/.buildkite/build
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${STACK_ROOT}"
+: "${RADPATH}"
+: "${LOCAL_BIN}"
+
+set -x
+stack config set system-ghc --global true
+stack config set install-ghc --global false
+set +x
+
+echo "--- Install Linters"
+set -x
+stack --local-bin-path="$LOCAL_BIN" build stylish-haskell hlint weeder
+export PATH="${LOCAL_BIN}:${PATH}"
+set +x
+
+echo "--- Lint: Formatting"
+scripts/check-fmt.sh
+
+echo "--- Lint: HLint"
+set -x
+stack exec -- hlint .
+set +x
+
+echo "--- Build"
+set -x
+stack build --fast --pedantic --test --no-run-tests
+set +x
+
+echo "--- Test"
+set -x
+stack test radicle-lang:doctest
+stack test radicle-lang:spec
+stack test radicle-repl:spec
+stack test radicle:spec
+
+stack exec -- radicle test/all.rad
+set +x
+
+echo "--- Lint: Weeder"
+set -x
+stack exec -- weeder --match
+set +x
+
+echo "--- Reference Doc and Swagger Spec"
+set -x
+mv docs/source/reference.rst oldref
+mv docs/source/daemon-api.yaml oldswagger
+stack run radicle-ref-doc
+
+if ! (diff oldref docs/source/reference.rst); then
+  echo "Reference docs are not checked in"
+  exit 1
+fi
+if ! (diff oldswagger docs/source/daemon-api.yaml); then
+  echo "Daemon swagger spec is not checked in"
+  exit 1
+fi
+set +x
+
+echo "--- Check Tutorial"
+set -x
+stack run radicle-doc docs/source/guide/Basics.lrad
+set +x

--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM haskell:8.6.3

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,18 @@
+env:
+  DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-build@sha256:874fbb260dd3e2636a08e14f60e80176774c45d4feebea1452da6d20affebccf"
+  DOCKER_FILE: .buildkite/docker/Dockerfile
+  # stack needs excessive amounts of tmp
+  BUILD_TMPDIR: /cache/tmp
+  BUILD_STACK_ROOT: /cache/.stack
+  BUILD_RADPATH: /build/rad-base/rad
+  BUILD_LOCAL_BIN: /cache/.local
+
+steps:
+- label: "Build"
+  commands:
+  - 'mkdir -p /cache/tmp'
+  - '.buildkite/build'
+  - 'rm -rf /cache/tmp'
+  agents:
+    production: "true"
+    platform: "linux"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,15 +43,12 @@ steps:
 
       stack build \
         --no-terminal \
-        stylish-haskell hlint weeder
-
-      stack build \
-        --no-terminal \
         --test \
         --dependencies-only
 
   - id: "Save cache"
-    waitFor: ["Build deps"]
+    waitFor:
+    - "Build deps"
     name: $_BUILD_IMAGE
     entrypoint: 'bash'
     env:
@@ -63,16 +60,6 @@ steps:
 
       source scripts/ci.sh
       save-cache
-
-  - id: "Format"
-    name: $_BUILD_IMAGE
-    env: ['STACK_ROOT=/workspace/.stack']
-    args: ['./scripts/check-fmt.sh']
-
-  - id: "Lint"
-    name: $_BUILD_IMAGE
-    env: ['STACK_ROOT=/workspace/.stack']
-    args: ['stack', 'exec', '--', 'hlint', '.']
 
   - id: "Build"
     name: $_BUILD_IMAGE
@@ -86,34 +73,11 @@ steps:
       stack build \
         --no-terminal \
         --fast \
-        --pedantic \
-        --test \
-        --no-run-tests
-
-  - id: "Test"
-    name: $_BUILD_IMAGE
-    env: ['STACK_ROOT=/workspace/.stack']
-    entrypoint: bash
-    args:
-    - '-c'
-    - |
-      set -euxo pipefail
-
-      stack test radicle-lang:doctest
-      stack test radicle-lang:spec
-      stack test radicle-repl:spec
-      stack test radicle:spec
-      RADPATH="$(pwd)/rad-base/rad" stack exec -- radicle test/all.rad
-
-  - id: "Lint (weeder)"
-    waitFor: ["Build"]
-    name: $_BUILD_IMAGE
-    env: ["STACK_ROOT=/workspace/.stack"]
-    args: ["stack", "exec", "--", "weeder", "--match"]
+        --pedantic
 
   - id: "Build rad-daemon-radicle image"
     waitFor:
-    - "Test"
+    - "Build"
     name: $_BUILD_IMAGE
     entrypoint: bash
     env:
@@ -140,42 +104,6 @@ steps:
         docker push "$image_name"
         docker push "$image_name:$tag"
       fi
-
-  - id: "Build reference document and swagger spec"
-    waitFor:
-    - "Build"
-    name: $_BUILD_IMAGE
-    env: ['STACK_ROOT=/workspace/.stack']
-    entrypoint: bash
-    args:
-    - '-c'
-    - |
-      set -euxo pipefail
-
-      mv docs/source/reference.rst oldref
-      mv docs/source/daemon-api.yaml oldswagger
-      RADPATH="$(pwd)/rad-base/rad" stack exec radicle-ref-doc
-      if ! (diff oldref docs/source/reference.rst); then
-        echo "Reference docs are not checked in"
-        exit 1
-      fi
-      if ! (diff oldswagger docs/source/daemon-api.yaml); then
-        echo "Daemon swagger spec is not checked in"
-        exit 1
-      fi
-
-  - id: "Check tutorial"
-    waitFor:
-    - "Build"
-    name: $_BUILD_IMAGE
-    env: ['STACK_ROOT=/workspace/.stack']
-    entrypoint: bash
-    args:
-    - '-c'
-    - |
-      set -euxo pipefail
-
-      RADPATH="$(pwd)/rad-base/rad" stack exec radicle-doc docs/source/guide/Basics.lrad
 
   - id: "Integration tests"
     waitFor:

--- a/scripts/check-fmt.sh
+++ b/scripts/check-fmt.sh
@@ -14,6 +14,6 @@ done
 formatted=$(mktemp -d "/tmp/oscoin-formatted.XXXXX")
 cp -R $base/* $formatted
 
+set -x
 stack exec -- stylish-haskell $formatted/**/**.hs --inplace
-
 diff -rq $base $formatted


### PR DESCRIPTION
E2E tests and packaging remain in cloudbuild for now, due to IPFS and docker compose shenanigans. As we're moving away from IPFS, we'll sunset cloudbuild wholesale.

Fixes radicle-dev/cocopoco#7